### PR TITLE
Add Init()

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,20 @@ import "golang.design/x/clipboard"
 
 ## API Usage
 
-Package `clipboard` provides three major APIs for manipulating the
-clipboard: `Read`, `Write`, and `Watch`. The most common operations are
-`Read` and `Write`. To use them, you can:
+Package clipboard provides cross platform clipboard access and supports
+macOS/Linux/Windows/Android/iOS platform. Before interacting with the
+clipboard, one must call Init to assert if it is possible to use this
+package:
+
+```go
+// Init returns an error if the package is not ready for use.
+err := clipboard.Init()
+if err != nil {
+      panic(err)
+}
+```
+
+The most common operations are `Read` and `Write`. To use them:
 
 ```go
 // write/read text format data of the clipboard, and

--- a/clipboard.go
+++ b/clipboard.go
@@ -59,10 +59,9 @@ import (
 
 var (
 	// activate only for running tests.
-	debug               = false
-	errUnavailable      = errors.New("clipboard unavailable")
-	errUnsupported      = errors.New("unsupported format")
-	errInvalidOperation = errors.New("invalid operation")
+	debug          = false
+	errUnavailable = errors.New("clipboard unavailable")
+	errUnsupported = errors.New("unsupported format")
 )
 
 // Format represents the format of clipboard data.
@@ -81,8 +80,20 @@ const (
 // guarantee one read at a time.
 var lock = sync.Mutex{}
 
-func Test() bool {
-	return test()
+// Init initializes the clipboard package. It returns an error
+// if the clipboard is not available to use. This may happen if the
+// target system lacks required dependency, such as libx11-dev in X11
+// environment. For example,
+//
+// 	err := clipboard.Init()
+// 	if err != nil {
+// 		...
+// 	}
+//
+// If Init returns an error, any subsequent Read/Write/Watch call
+// may result in an unrecoverable panic.
+func Init() error {
+	return initialize()
 }
 
 // Read returns a chunk of bytes of the clipboard data if it presents

--- a/clipboard.go
+++ b/clipboard.go
@@ -6,8 +6,14 @@
 
 /*
 Package clipboard provides cross platform clipboard access and supports
-macOS/Linux/Windows/Android/iOS platform. There are three major APIs
-to interact with the clipboard: `Read`, `Write`, and `Watch`.
+macOS/Linux/Windows/Android/iOS platform. Before interacting with the
+clipboard, one must call Init to assert if it is possible to use this
+package:
+
+	err := clipboard.Init()
+	if err != nil {
+		panic(err)
+	}
 
 The most common operations are `Read` and `Write`. To use them:
 
@@ -87,7 +93,7 @@ var lock = sync.Mutex{}
 //
 // 	err := clipboard.Init()
 // 	if err != nil {
-// 		...
+// 		panic(err)
 // 	}
 //
 // If Init returns an error, any subsequent Read/Write/Watch call

--- a/clipboard.go
+++ b/clipboard.go
@@ -81,6 +81,10 @@ const (
 // guarantee one read at a time.
 var lock = sync.Mutex{}
 
+func Test() bool {
+	return test()
+}
+
 // Read returns a chunk of bytes of the clipboard data if it presents
 // in the desired format t presents. Otherwise, it returns nil.
 func Read(t Format) []byte {

--- a/clipboard_android.go
+++ b/clipboard_android.go
@@ -28,6 +28,10 @@ import (
 	"golang.org/x/mobile/app"
 )
 
+func test() bool {
+	return true
+}
+
 func read(t Format) (buf []byte, err error) {
 	switch t {
 	case FmtText:

--- a/clipboard_android.go
+++ b/clipboard_android.go
@@ -28,9 +28,7 @@ import (
 	"golang.org/x/mobile/app"
 )
 
-func test() bool {
-	return true
-}
+func initialize() error { return nil }
 
 func read(t Format) (buf []byte, err error) {
 	switch t {
@@ -48,9 +46,9 @@ func read(t Format) (buf []byte, err error) {
 		})
 		return []byte(s), nil
 	case FmtImage:
-		return nil, errors.New("unsupported")
+		return nil, errUnsupported
 	default:
-		return nil, errors.New("unsupported")
+		return nil, errUnsupported
 	}
 }
 
@@ -70,9 +68,9 @@ func write(t Format, buf []byte) (<-chan struct{}, error) {
 		})
 		return done, nil
 	case FmtImage:
-		return nil, errors.New("unsupported")
+		return nil, errUnsupported
 	default:
-		return nil, errors.New("unsupported")
+		return nil, errUnsupported
 	}
 }
 

--- a/clipboard_darwin.go
+++ b/clipboard_darwin.go
@@ -28,9 +28,7 @@ import (
 	"unsafe"
 )
 
-func test() bool {
-	return true
-}
+func initialize() error { return nil }
 
 func read(t Format) (buf []byte, err error) {
 	var (
@@ -72,9 +70,11 @@ func write(t Format, buf []byte) (<-chan struct{}, error) {
 			ok = C.clipboard_write_image(unsafe.Pointer(&buf[0]),
 				C.NSInteger(len(buf)))
 		}
+	default:
+		return nil, errUnsupported
 	}
 	if ok != 0 {
-		return nil, errInvalidOperation
+		return nil, errUnavailable
 	}
 
 	// use unbuffered data to prevent goroutine leak

--- a/clipboard_darwin.go
+++ b/clipboard_darwin.go
@@ -28,6 +28,10 @@ import (
 	"unsafe"
 )
 
+func test() bool {
+	return true
+}
+
 func read(t Format) (buf []byte, err error) {
 	var (
 		data unsafe.Pointer

--- a/clipboard_ios.go
+++ b/clipboard_ios.go
@@ -26,18 +26,16 @@ import (
 	"unsafe"
 )
 
-func test() bool {
-	return true
-}
+func initialize() error { return nil }
 
 func read(t Format) (buf []byte, err error) {
 	switch t {
 	case FmtText:
 		return []byte(C.GoString(C.clipboard_read_string())), nil
 	case FmtImage:
-		return nil, errors.New("unimplemented")
+		return nil, errUnsupported
 	default:
-		return nil, errors.New("unimplemented")
+		return nil, errUnsupported
 	}
 }
 
@@ -52,9 +50,9 @@ func write(t Format, buf []byte) (<-chan struct{}, error) {
 		C.clipboard_write_string(cs)
 		return done, nil
 	case FmtImage:
-		return nil, errors.New("unimplemented")
+		return nil, errUnsupported
 	default:
-		return nil, errors.New("unimplemented")
+		return nil, errUnsupported
 	}
 }
 

--- a/clipboard_ios.go
+++ b/clipboard_ios.go
@@ -26,6 +26,10 @@ import (
 	"unsafe"
 )
 
+func test() bool {
+	return true
+}
+
 func read(t Format) (buf []byte, err error) {
 	switch t {
 	case FmtText:

--- a/clipboard_linux.go
+++ b/clipboard_linux.go
@@ -61,7 +61,7 @@ Then this package should be ready to use.
 
 func initialize() error {
 	ok := C.clipboard_test()
-	if !ok {
+	if ok != 0 {
 		return fmt.Errorf(helpmsg, errUnavailable)
 	}
 	return nil

--- a/clipboard_linux.go
+++ b/clipboard_linux.go
@@ -67,8 +67,6 @@ func initialize() error {
 	return nil
 }
 
-var canAccessClipbord = false
-
 func read(t Format) (buf []byte, err error) {
 	switch t {
 	case FmtText:

--- a/clipboard_nocgo.go
+++ b/clipboard_nocgo.go
@@ -1,9 +1,13 @@
 //go:build !windows && !cgo
 // +build !windows,!cgo
 
-package clipboard
+package
 
 import "context"
+
+func test() bool {
+	panic("clipboard: cannot use when CGO_ENABLED=0")
+}
 
 func read(t Format) (buf []byte, err error) {
 	panic("clipboard: cannot use when CGO_ENABLED=0")

--- a/clipboard_nocgo.go
+++ b/clipboard_nocgo.go
@@ -1,11 +1,11 @@
 //go:build !windows && !cgo
 // +build !windows,!cgo
 
-package
+package clipboard
 
 import "context"
 
-func test() bool {
+func initialize() error {
 	panic("clipboard: cannot use when CGO_ENABLED=0")
 }
 

--- a/clipboard_test.go
+++ b/clipboard_test.go
@@ -23,6 +23,19 @@ func init() {
 	clipboard.Debug = true
 }
 
+func TestClipboardTest(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		if val, ok := os.LookupEnv("CGO_ENABLED"); ok && val == "0" {
+			t.Skip("CGO_ENABLED is set to 0")
+		}
+	}
+	t.Run("test", func(t *testing.T) {
+		if !clipboard.Test() {
+			t.Fatalf("clipboard test failed")
+		}
+	})
+}
+
 func TestClipboard(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		if val, ok := os.LookupEnv("CGO_ENABLED"); ok && val == "0" {

--- a/clipboard_test.go
+++ b/clipboard_test.go
@@ -23,15 +23,16 @@ func init() {
 	clipboard.Debug = true
 }
 
-func TestClipboardTest(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		if val, ok := os.LookupEnv("CGO_ENABLED"); ok && val == "0" {
-			t.Skip("CGO_ENABLED is set to 0")
-		}
+func TestClipboardInit(t *testing.T) {
+	if val, ok := os.LookupEnv("CGO_ENABLED"); !ok || val != "0" {
+		t.Skip("CGO_ENABLED is set to 1")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not need to check for cgo")
 	}
 	t.Run("test", func(t *testing.T) {
-		if !clipboard.Test() {
-			t.Fatalf("clipboard test failed")
+		if err := clipboard.Init(); err != nil {
+			t.Fatal(err)
 		}
 	})
 }
@@ -268,7 +269,7 @@ func BenchmarkClipboard(b *testing.B) {
 }
 
 func TestClipboardNoCgo(t *testing.T) {
-	if val, ok := os.LookupEnv("CGO_ENABLED"); ok && val == "1" {
+	if val, ok := os.LookupEnv("CGO_ENABLED"); !ok || val != "0" {
 		t.Skip("CGO_ENABLED is set to 1")
 	}
 	if runtime.GOOS == "windows" {

--- a/clipboard_test.go
+++ b/clipboard_test.go
@@ -43,6 +43,9 @@ func TestClipboardInit(t *testing.T) {
 		clipboard.Init()
 	})
 	t.Run("with-cgo", func(t *testing.T) {
+		if val, ok := os.LookupEnv("CGO_ENABLED"); ok && val == "0" {
+			t.Skip("CGO_ENABLED is set to 0")
+		}
 		if runtime.GOOS != "linux" {
 			t.Skip("Only Linux may return error at the moment.")
 		}

--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -27,6 +27,10 @@ import (
 	"unsafe"
 )
 
+func test() bool {
+	return true
+}
+
 // readText reads the clipboard and returns the text data if presents.
 // The caller is responsible for opening/closing the clipboard before
 // calling this function.

--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -27,9 +27,7 @@ import (
 	"unsafe"
 )
 
-func test() bool {
-	return true
-}
+func initialize() error { return nil }
 
 // readText reads the clipboard and returns the text data if presents.
 // The caller is responsible for opening/closing the clipboard before

--- a/cmd/gclip-gui/main.go
+++ b/cmd/gclip-gui/main.go
@@ -207,6 +207,13 @@ func (g *GclipApp) OnDraw() {
 	g.l.Draw(g.siz)
 }
 
+func init() {
+	err := clipboard.Init()
+	if err != nil {
+		panic(err)
+	}
+}
+
 func main() {
 	app.Main(func(a app.App) {
 		gclip := GclipApp{app: a}

--- a/cmd/gclip/main.go
+++ b/cmd/gclip/main.go
@@ -43,6 +43,13 @@ var (
 	file = flag.String("f", "", "source or destination to a given file path")
 )
 
+func init() {
+	err := clipboard.Init()
+	if err != nil {
+		panic(err)
+	}
+}
+
 func main() {
 	flag.Usage = usage
 	flag.Parse()

--- a/cmd/gclip/main.go
+++ b/cmd/gclip/main.go
@@ -7,7 +7,6 @@
 package main // go install golang.design/x/clipboard/cmd/gclip@latest
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -42,10 +41,6 @@ var (
 	in   = flag.Bool("copy", false, "copy data to clipboard")
 	out  = flag.Bool("paste", false, "paste data from clipboard")
 	file = flag.String("f", "", "source or destination to a given file path")
-)
-
-var (
-	errUnsupported = errors.New("unsupported data format")
 )
 
 func main() {

--- a/example_test.go
+++ b/example_test.go
@@ -18,17 +18,32 @@ import (
 )
 
 func ExampleWrite() {
+	err := clipboard.Init()
+	if err != nil {
+		panic(err)
+	}
+
 	clipboard.Write(clipboard.FmtText, []byte("Hello, 世界"))
 	// Output:
 }
 
 func ExampleRead() {
+	err := clipboard.Init()
+	if err != nil {
+		panic(err)
+	}
+
 	fmt.Println(string(clipboard.Read(clipboard.FmtText)))
 	// Output:
 	// Hello, 世界
 }
 
 func ExampleWatch() {
+	err := clipboard.Init()
+	if err != nil {
+		panic(err)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 	defer cancel()
 

--- a/export_test.go
+++ b/export_test.go
@@ -7,4 +7,7 @@
 package clipboard
 
 // for debugging errors
-var Debug = debug
+var (
+	Debug          = debug
+	ErrUnavailable = errUnavailable
+)


### PR DESCRIPTION
If you are using Linux without X11 enabled, an error will occur at the time of import.
Add Test() methods to check if the clipboard is accessible for conditional branching.

Fixes #19 