### PR TITLE
fix linux initialization bug.

### DIFF
--- a/clipboard_linux.c
+++ b/clipboard_linux.c
@@ -41,7 +41,7 @@ int initX11() {
 	}
 	libX11 = dlopen("libX11.so", RTLD_LAZY);
 	if (!libX11) {
-		return -1;
+		return 0;
 	}
 	P_XOpenDisplay = (Display* (*)(int)) dlsym(libX11, "XOpenDisplay");
 	P_XCloseDisplay = (void (*)(Display*)) dlsym(libX11, "XCloseDisplay");


### PR DESCRIPTION
make initX11() return 0 in the event of dlopen failing. This allows the test for failure in clipboard_test() to work as expected. 