### PR TITLE
Fix wrong y-axis range in writeImage() on Windows

### DIFF
--- a/clipboard_test.go
+++ b/clipboard_test.go
@@ -10,6 +10,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"image"
+	"image/color"
 	"image/png"
 	"os"
 	"reflect"
@@ -95,8 +97,19 @@ func TestClipboard(t *testing.T) {
 		incorrect := 0
 		for i := 0; i < w; i++ {
 			for j := 0; j < h; j++ {
-				want := img1.At(i, j)
-				got := img2.At(i, j)
+				var want, got color.Color
+				switch img1.(type) {
+				case *image.RGBA:
+					want = img1.(*image.RGBA).RGBA64At(i, j)
+				case *image.NRGBA:
+					want = img1.(*image.NRGBA).RGBA64At(i, j)
+				}
+				switch img2.(type) {
+				case *image.RGBA:
+					got = img2.(*image.RGBA).RGBA64At(i, j)
+				case *image.NRGBA:
+					got = img2.(*image.NRGBA).RGBA64At(i, j)
+				}
 
 				if !reflect.DeepEqual(want, got) {
 					t.Logf("read data from clipbaord is inconsistent with previous written data, pix: (%d,%d), got: %+v, want: %+v", i, j, got, want)

--- a/clipboard_test.go
+++ b/clipboard_test.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"image"
 	"image/color"
 	"image/png"
 	"os"
@@ -97,19 +96,18 @@ func TestClipboard(t *testing.T) {
 		incorrect := 0
 		for i := 0; i < w; i++ {
 			for j := 0; j < h; j++ {
-				var want, got color.Color
-				switch img1.(type) {
-				case *image.RGBA:
-					want = img1.(*image.RGBA).RGBA64At(i, j)
-				case *image.NRGBA:
-					want = img1.(*image.NRGBA).RGBA64At(i, j)
-				}
-				switch img2.(type) {
-				case *image.RGBA:
-					got = img2.(*image.RGBA).RGBA64At(i, j)
-				case *image.NRGBA:
-					got = img2.(*image.NRGBA).RGBA64At(i, j)
-				}
+				want := color.RGBA{}
+				wr, wg, wb, wa := img1.At(i, j).RGBA()
+				want.R = uint8(wr)
+				want.G = uint8(wg)
+				want.B = uint8(wb)
+				want.A = uint8(wa)
+				got := color.RGBA{}
+				gr, gg, gb, ga := img2.At(i, j).RGBA()
+				got.R = uint8(gr)
+				got.G = uint8(gg)
+				got.B = uint8(gb)
+				got.A = uint8(ga)
 
 				if !reflect.DeepEqual(want, got) {
 					t.Logf("read data from clipbaord is inconsistent with previous written data, pix: (%d,%d), got: %+v, want: %+v", i, j, got, want)

--- a/clipboard_test.go
+++ b/clipboard_test.go
@@ -96,18 +96,20 @@ func TestClipboard(t *testing.T) {
 		incorrect := 0
 		for i := 0; i < w; i++ {
 			for j := 0; j < h; j++ {
-				want := color.RGBA{}
 				wr, wg, wb, wa := img1.At(i, j).RGBA()
-				want.R = uint8(wr)
-				want.G = uint8(wg)
-				want.B = uint8(wb)
-				want.A = uint8(wa)
-				got := color.RGBA{}
 				gr, gg, gb, ga := img2.At(i, j).RGBA()
-				got.R = uint8(gr)
-				got.G = uint8(gg)
-				got.B = uint8(gb)
-				got.A = uint8(ga)
+				want := color.RGBA{
+					R: uint8(wr),
+					G: uint8(wg),
+					B: uint8(wb),
+					A: uint8(wa),
+				}
+				got := color.RGBA{
+					R: uint8(gr),
+					G: uint8(gg),
+					B: uint8(gb),
+					A: uint8(ga),
+				}
 
 				if !reflect.DeepEqual(want, got) {
 					t.Logf("read data from clipbaord is inconsistent with previous written data, pix: (%d,%d), got: %+v, want: %+v", i, j, got, want)
@@ -116,9 +118,7 @@ func TestClipboard(t *testing.T) {
 			}
 		}
 
-		// FIXME: it looks like windows can produce incorrect pixels when y == 0.
-		// Needs more investigation.
-		if incorrect > w {
+		if incorrect > 0 {
 			t.Fatalf("read data from clipboard contains too much inconsistent pixels to the previous written data, number of incorrect pixels: %v", incorrect)
 		}
 	})

--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -145,7 +145,7 @@ func readImage() ([]byte, error) {
 			// xhat := (x + int(info.Width-3)) % int(info.Width)
 
 			xhat := (x + int(info.Width)) % int(info.Width)
-			yhat := int(info.Height) - y
+			yhat := int(info.Height) - 1 - y
 			r := data[idx+2]
 			g := data[idx+1]
 			b := data[idx+0]

--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -139,11 +139,6 @@ func readImage() ([]byte, error) {
 	for y := 0; y < int(info.Height); y++ {
 		for x := 0; x < int(info.Width); x++ {
 			idx := offset + 4*(y*stride+x)
-
-			// FIXME: It seems that reading from clipboard data causes 3 pixels
-			// offset. I don't have a clear evidence on the root reason yet.
-			// xhat := (x + int(info.Width-3)) % int(info.Width)
-
 			xhat := (x + int(info.Width)) % int(info.Width)
 			yhat := int(info.Height) - 1 - y
 			r := data[idx+2]
@@ -235,13 +230,6 @@ func writeImage(buf []byte) error {
 	for y := 0; y < height; y++ {
 		for x := 0; x < width; x++ {
 			idx := int(offset) + 4*(y*width+x)
-
-			// FIXME: It seems that reading from clipboard data causes 3 pixels
-			// offset. I don't have a clear evidence on the root reason yet.
-			// xhat := (x + int(width) - 3) % int(width)
-			// yhat := int(height) - y
-			// r, g, b, a := img.At(xhat, yhat).RGBA()
-
 			r, g, b, a := img.At(x, height-1-y).RGBA()
 			data[idx+2] = uint8(r)
 			data[idx+1] = uint8(g)

--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -242,7 +242,7 @@ func writeImage(buf []byte) error {
 			// yhat := int(height) - y
 			// r, g, b, a := img.At(xhat, yhat).RGBA()
 
-			r, g, b, a := img.At(x, height-y).RGBA()
+			r, g, b, a := img.At(x, height-1-y).RGBA()
 			data[idx+2] = uint8(r)
 			data[idx+1] = uint8(g)
 			data[idx+0] = uint8(b)


### PR DESCRIPTION
for y := 0; y < height; y++ { height-y }
returns height ~ 1