### PR TITLE
Remove unused `const` and `type`

### DIFF
--- a/clipboard_linux.go
+++ b/clipboard_linux.go
@@ -159,10 +159,6 @@ func watch(ctx context.Context, t Format) <-chan []byte {
 	return recv
 }
 
-type syncChan struct {
-	c chan int
-}
-
 //export syncStatus
 func syncStatus(h uintptr, val int) {
 	v := cgo.Handle(h).Value().(chan int)

--- a/cmd/gclip-gui/main.go
+++ b/cmd/gclip-gui/main.go
@@ -86,8 +86,6 @@ func (l *Label) SetLabel(s string) {
 }
 
 const (
-	fontWidth  = 5
-	fontHeight = 7
 	lineWidth  = 100
 	lineHeight = 120
 )


### PR DESCRIPTION
It seems some `const` and `type` are unused. This PR just removed those.