### PR TITLE
all: remove old format tag lines

### DIFF
--- a/clipboard_android.c
+++ b/clipboard_android.c
@@ -5,7 +5,6 @@
 // Written by Changkun Ou <changkun.de>
 
 //go:build android
-// +build android
 
 #include <android/log.h>
 #include <jni.h>

--- a/clipboard_android.go
+++ b/clipboard_android.go
@@ -5,7 +5,6 @@
 // Written by Changkun Ou <changkun.de>
 
 //go:build android
-// +build android
 
 package clipboard
 

--- a/clipboard_darwin.go
+++ b/clipboard_darwin.go
@@ -5,7 +5,6 @@
 // Written by Changkun Ou <changkun.de>
 
 //go:build darwin && !ios
-// +build darwin,!ios
 
 package clipboard
 

--- a/clipboard_darwin.m
+++ b/clipboard_darwin.m
@@ -5,7 +5,6 @@
 // Written by Changkun Ou <changkun.de>
 
 //go:build darwin && !ios
-// +build darwin,!ios
 
 // Interact with NSPasteboard using Objective-C
 // https://developer.apple.com/documentation/appkit/nspasteboard?language=objc

--- a/clipboard_ios.go
+++ b/clipboard_ios.go
@@ -5,7 +5,6 @@
 // Written by Changkun Ou <changkun.de>
 
 //go:build ios
-// +build ios
 
 package clipboard
 

--- a/clipboard_ios.m
+++ b/clipboard_ios.m
@@ -5,7 +5,6 @@
 // Written by Changkun Ou <changkun.de>
 
 //go:build ios
-// +build ios
 
 #import <UIKit/UIKit.h>
 #import <MobileCoreServices/MobileCoreServices.h>

--- a/clipboard_linux.c
+++ b/clipboard_linux.c
@@ -5,7 +5,6 @@
 // Written by Changkun Ou <changkun.de>
 
 //go:build linux && !android
-// +build linux,!android
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/clipboard_linux.go
+++ b/clipboard_linux.go
@@ -5,7 +5,6 @@
 // Written by Changkun Ou <changkun.de>
 
 //go:build linux && !android
-// +build linux,!android
 
 package clipboard
 

--- a/clipboard_nocgo.go
+++ b/clipboard_nocgo.go
@@ -1,5 +1,4 @@
 //go:build !windows && !cgo
-// +build !windows,!cgo
 
 package clipboard
 

--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -5,7 +5,6 @@
 // Written by Changkun Ou <changkun.de>
 
 //go:build windows
-// +build windows
 
 package clipboard
 

--- a/cmd/gclip-gui/main.go
+++ b/cmd/gclip-gui/main.go
@@ -5,7 +5,6 @@
 // Written by Changkun Ou <changkun.de>
 
 //go:build android || ios || linux || darwin || windows
-// +build android ios linux darwin windows
 
 // This is a very basic example for verification purpose that
 // demonstrates how the golang.design/x/clipboard can interact

--- a/example_test.go
+++ b/example_test.go
@@ -5,7 +5,6 @@
 // Written by Changkun Ou <changkun.de>
 
 //go:build cgo
-// +build cgo
 
 package clipboard_test
 


### PR DESCRIPTION
The new format is supported since 1.17 and no need to use the old format now.