### PR TITLE
Add support for TIFF images on darwin

### DIFF
--- a/clipboard_darwin.m
+++ b/clipboard_darwin.m
@@ -28,8 +28,16 @@ unsigned int clipboard_read_image(void **out) {
 	NSPasteboard * pasteboard = [NSPasteboard generalPasteboard];
 	NSData *data = [pasteboard dataForType:NSPasteboardTypePNG];
 	if (data == nil) {
-		return 0;
-	}
+        data = [pasteboard dataForType:NSPasteboardTypeTIFF];
+        if (data == nil) {
+            return 0;
+        }
+        NSBitmapImageRep *bitmap = [NSBitmapImageRep imageRepWithData: data];
+        if (bitmap == nil) {
+            return 0;
+        }
+        data = [bitmap representationUsingType:NSBitmapImageFileTypePNG properties: @{}];
+    }
 	NSUInteger siz = [data length];
 	*out = malloc(siz);
 	[data getBytes: *out length: siz];


### PR DESCRIPTION
Since the default image format for the clipboard on macOS is tiff (that is, when you click "Copy Image" on any meny on macOS it will copy the image data in the TIFF format), it seems useful to add support for this in the `clipboard_darwin.m` file.

It is pretty simple: if the format is not PNG, we try to read TIFF; then, if successful, we convert it to a bitmap and, finally, to PNG. In this manner we return the same PNG data, and the user does not neet do modify his code at all.