### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,3 +7,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libx11-dev \
   xvfb \
   && rm -rf /var/lib/apt/lists/*
+
+# run virtual display init on start of the container
+COPY .devcontainer/docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+
+# keep the container running since the devcontainer will start its own processes
+CMD [ "sleep", "infinity" ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+ARG VARIANT=1
+FROM mcr.microsoft.com/devcontainers/go:${VARIANT}
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libegl1-mesa-dev \
+  libgles2-mesa-dev \
+  libx11-dev \
+  xvfb \
+  && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 {
 	"name": "golang.design: clipboard",
 	"build": {
+		"context": "..",
 		"dockerfile": "Dockerfile",
 		"args": {
 			"VARIANT": "1.21-bookworm"
@@ -10,5 +11,7 @@
 	},
 	// Install dependencies and other setup tasks
 	"postCreateCommand": ".devcontainer/setup.sh",
+	// Allow the Dockerfile's command to run (creates virtual display for X11 to support clipboard)
+	"overrideCommand": false,
 	"remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/go
+{
+	"name": "golang.design: clipboard",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"VARIANT": "1.21-bookworm"
+		}
+	},
+	// Install dependencies and other setup tasks
+	"postCreateCommand": ".devcontainer/setup.sh",
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/docker-entrypoint.sh
+++ b/.devcontainer/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+echo "Running docker-entrypoint.sh"
+
+# create a virtual frame buffer for X11
+nohup Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+
+export DISPLAY=:99.0
+echo "export DISPLAY=:99.0" > /etc/profile.d/01-export-virtual-display.sh
+chmod +x /etc/profile.d/01-export-virtual-display.sh
+
+exec "$@"

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# install module dependencies
+go get
+
+# install clipboard
+go install golang.design/x/clipboard/cmd/gclip@latest


### PR DESCRIPTION
devcontainers can be used by IDEs like VSCode to build the whole development environment in a container. This allows you to keep dependencies, build, and all development aspects separated from any development. It also allows contributors to instantly have a working, standardized development environment. It also allows cloud development tools like GitHub Codespaces be automatically setup with the desired environment.

See https://containers.dev/ for more details