### PR TITLE
linux: send the correct for TARGETS request

### DIFF
--- a/clipboard_linux.c
+++ b/clipboard_linux.c
@@ -171,7 +171,7 @@ int clipboard_write(char *typ, unsigned char *buf, size_t n, uintptr_t handle) {
                 // Reply atoms for supported targets, other clients should
                 // request the clipboard again and obtain the data if their
                 // implementation is correct.
-                Atom targets[] = { atomString, atomImage };
+                Atom targets[] = { targetsAtom, target };
                 R = (*P_XChangeProperty)(ev.display, ev.requestor, ev.property,
                     XA_ATOM, 32, PropModeReplace,
                     (unsigned char *)&targets, sizeof(targets)/sizeof(Atom));


### PR DESCRIPTION
For the X11 implementation, the code always send text and `image/png` for `TARGETS` request. This means that rich-content applications (like Chromium) would always try to request all the available content types (since the Web does allow querying different types of clipboard content) and this causes Chromium and Electron to hang.

This also confuses clipboard managers, which tries to check if they can support saving and taking over clipboard content based on `TARGETS`. In particular, this makes KDE Plasma 6's clipboard manager NOT recognize anything copied with this package.

This PR makes it send the correct pair of targets (`TARGETS`, text or `image/png`) for SelectionRequest.
This fixes hang/crash when pasting into Chromium and Electron-based apps, and the clipboard content shows up in KDE Plasma's clipboard manager.
