### PR TITLE
Do not panic when initialize is called without cgo

### DIFF
--- a/clipboard_nocgo.go
+++ b/clipboard_nocgo.go
@@ -7,8 +7,12 @@ import (
 	"errors"
 )
 
+var (
+	ErrNoCGOCannotUse = errors.New("clipboard: cannot use when CGO_ENABLED=0")
+)
+
 func initialize() error {
-	return errors.New("clipboard: cannot use when CGO_ENABLED=0")
+	return ErrNoCGOCannotUse
 }
 
 func read(t Format) (buf []byte, err error) {

--- a/clipboard_nocgo.go
+++ b/clipboard_nocgo.go
@@ -2,10 +2,13 @@
 
 package clipboard
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 func initialize() error {
-	panic("clipboard: cannot use when CGO_ENABLED=0")
+	return errors.New("clipboard: cannot use when CGO_ENABLED=0")
 }
 
 func read(t Format) (buf []byte, err error) {

--- a/clipboard_test.go
+++ b/clipboard_test.go
@@ -34,14 +34,9 @@ func TestClipboardInit(t *testing.T) {
 			t.Skip("Windows does not need to check for cgo")
 		}
 
-		defer func() {
-			if r := recover(); r != nil {
-				return
-			}
-			t.Fatalf("expect to fail when CGO_ENABLED=0")
-		}()
-
-		clipboard.Init()
+		if err := clipboard.Init(); err != nil && !errors.Is(err, clipboard.ErrNoCGOCannotUse) {
+			t.Fatalf("expect 'clipboard: cannot use when CGO_ENABLED=0', but got: %v", err)
+		}
 	})
 	t.Run("with-cgo", func(t *testing.T) {
 		if val, ok := os.LookupEnv("CGO_ENABLED"); ok && val == "0" {

--- a/clipboard_test.go
+++ b/clipboard_test.go
@@ -35,7 +35,7 @@ func TestClipboardInit(t *testing.T) {
 		}
 
 		if err := clipboard.Init(); err != nil && !errors.Is(err, clipboard.ErrNoCGOCannotUse) {
-			t.Fatalf("expect 'clipboard: cannot use when CGO_ENABLED=0', but got: %v", err)
+			t.Fatalf("expect ErrNoCGOCannotUse, but got: %v", err)
 		}
 	})
 	t.Run("with-cgo", func(t *testing.T) {


### PR DESCRIPTION
Closes #57 

This disables the forced panic when initialize is called when CGO is disabled, so that the caller can decide whether a termination is appropriate or not.