### PR TITLE
Fix Linux read error handling

### DIFF
--- a/clipboard_linux.go
+++ b/clipboard_linux.go
@@ -78,6 +78,12 @@ func readc(t string) ([]byte, error) {
 
 	var data *C.char
 	n := C.clipboard_read(ct, &data)
+	switch C.long(n) {
+	case -1:
+		return nil, errUnavailable
+	case -2:
+		return nil, errUnsupported
+	}
 	if data == nil {
 		return nil, errUnavailable
 	}


### PR DESCRIPTION
## Summary
- check signed return values in `readc` on Linux

## Testing
- `go vet ./...` *(fails: fatal error: GLES3/gl3.h: No such file or directory)*
- `go test ./...` *(fails to build due to missing X11/GL dependencies and clipboard unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_683f712b427883258da9f1d2c33d23c7