### PR TITLE
linux: fix grammar in clipboard_read comment

### DIFF
--- a/clipboard_linux.c
+++ b/clipboard_linux.c
@@ -217,7 +217,7 @@ unsigned long read_data(XSelectionEvent *sev, Atom sel, Atom prop, Atom target, 
 }
 
 // clipboard_read reads the clipboard selection in given format typ.
-// the readed bytes is written into buf and returns the size of the buffer.
+// the read bytes are written into buf and returns the size of the buffer.
 //
 // The caller of this function should responsible for the free of the buf.
 unsigned long clipboard_read(char* typ, char **buf) {


### PR DESCRIPTION
## Summary
- correct grammar in clipboard_read comment in Linux C implementation

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_683f713454848325a20d9ce9b0d45381