### PR TITLE
Add watch channel closure check

### DIFF
--- a/clipboard_test.go
+++ b/clipboard_test.go
@@ -262,6 +262,7 @@ func TestClipboardWatch(t *testing.T) {
 			}
 		}
 	}(ctx)
+loop:
 	for {
 		select {
 		case <-ctx.Done():
@@ -269,19 +270,27 @@ func TestClipboardWatch(t *testing.T) {
 				t.Fatalf("clipboard watch never receives a notification")
 			}
 			t.Log(string(lastRead))
-			return
+			break loop
 		case data, ok := <-changed:
 			if !ok {
 				if string(lastRead) == "" {
 					t.Fatalf("clipboard watch never receives a notification")
 				}
-				return
+				break loop
 			}
 			if !bytes.Equal(data, want) {
 				t.Fatalf("received data from watch mismatch, want: %v, got %v", string(want), string(data))
 			}
 			lastRead = data
 		}
+	}
+	select {
+	case _, ok := <-changed:
+		if ok {
+			t.Fatalf("changed channel should be closed after ctx.Done")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for changed to be closed")
 	}
 }
 


### PR DESCRIPTION
## Summary
- ensure TestClipboardWatch waits for the watch channel to close
- prevent blocking by using select with timeout

## Testing
- `go test ./...` *(fails: missing GLES3/gl3.h and clipboard unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_683f71422c1c8325b9d97158fe6a51e9