### PR TITLE
Ensure ticker cleanup in watch functions

### DIFF
--- a/clipboard_android.go
+++ b/clipboard_android.go
@@ -81,6 +81,7 @@ func watch(ctx context.Context, t Format) <-chan []byte {
 	ti := time.NewTicker(time.Second)
 	last := Read(t)
 	go func() {
+		defer ti.Stop()
 		for {
 			select {
 			case <-ctx.Done():

--- a/clipboard_darwin.go
+++ b/clipboard_darwin.go
@@ -100,6 +100,7 @@ func watch(ctx context.Context, t Format) <-chan []byte {
 	ti := time.NewTicker(time.Second)
 	lastCount := C.long(C.clipboard_change_count())
 	go func() {
+		defer ti.Stop()
 		for {
 			select {
 			case <-ctx.Done():

--- a/clipboard_ios.go
+++ b/clipboard_ios.go
@@ -59,6 +59,7 @@ func watch(ctx context.Context, t Format) <-chan []byte {
 	ti := time.NewTicker(time.Second)
 	last := Read(t)
 	go func() {
+		defer ti.Stop()
 		for {
 			select {
 			case <-ctx.Done():

--- a/clipboard_linux.go
+++ b/clipboard_linux.go
@@ -138,6 +138,7 @@ func watch(ctx context.Context, t Format) <-chan []byte {
 	ti := time.NewTicker(time.Second)
 	last := Read(t)
 	go func() {
+		defer ti.Stop()
 		for {
 			select {
 			case <-ctx.Done():

--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -404,6 +404,7 @@ func watch(ctx context.Context, t Format) <-chan []byte {
 	go func() {
 		// not sure if we are too slow or the user too fast :)
 		ti := time.NewTicker(time.Second)
+		defer ti.Stop()
 		cnt, _, _ := getClipboardSequenceNumber.Call()
 		ready <- struct{}{}
 		for {


### PR DESCRIPTION
## Summary
- add `defer ti.Stop()` to cleanup tickers in all OS watch implementations

## Testing
- `go vet ./...` *(fails: `GLES3/gl3.h` missing)*
- `go test ./...` *(fails: X11/display not found and other build issues)*

------
https://chatgpt.com/codex/tasks/task_e_683f892bd430832588013e1b4aafab0e