### PR TITLE
Upgrade to Go 1.24

### DIFF
--- a/.github/workflows/clipboard.yml
+++ b/.github/workflows/clipboard.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.17.x', '1.18.x', '1.19.x', '1.20.x']
+        go: ['1.24.x']
     steps:
     - name: Install and run dependencies (xvfb libx11-dev)
       if: ${{ runner.os == 'Linux' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # Written by Changkun Ou <changkun.de>
 
-FROM golang:1.17
+FROM golang:1.24
 RUN apt-get update && apt-get install -y \
       xvfb libx11-dev libegl1-mesa-dev libgles2-mesa-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module golang.design/x/clipboard
 
-go 1.17
+go 1.24
 
 require (
 	golang.org/x/image v0.6.0


### PR DESCRIPTION
## Summary
- update module `go` directive to 1.24
- use `golang:1.24` in the Dockerfile
- run CI on Go 1.24

## Testing
- `go mod tidy` *(fails: forbidden download)*
- `go test ./...` *(fails: forbidden download)*

------
https://chatgpt.com/codex/tasks/task_e_68440dee06cc8325a3ae8acd7fd8ba38