### PR TITLE
Handle CGO disabled with error

### DIFF
--- a/clipboard.go
+++ b/clipboard.go
@@ -68,6 +68,7 @@ var (
 	debug          = false
 	errUnavailable = errors.New("clipboard unavailable")
 	errUnsupported = errors.New("unsupported format")
+	errNoCgo       = errors.New("clipboard: cannot use when CGO_ENABLED=0")
 )
 
 // Format represents the format of clipboard data.
@@ -85,8 +86,8 @@ var (
 	// Due to the limitation on operating systems (such as darwin),
 	// concurrent read can even cause panic, use a global lock to
 	// guarantee one read at a time.
-	lock = sync.Mutex{}
-	initOnce sync.Once
+	lock      = sync.Mutex{}
+	initOnce  sync.Once
 	initError error
 )
 
@@ -95,10 +96,10 @@ var (
 // target system lacks required dependency, such as libx11-dev in X11
 // environment. For example,
 //
-// 	err := clipboard.Init()
-// 	if err != nil {
-// 		panic(err)
-// 	}
+//	err := clipboard.Init()
+//	if err != nil {
+//		panic(err)
+//	}
 //
 // If Init returns an error, any subsequent Read/Write/Watch call
 // may result in an unrecoverable panic.

--- a/clipboard_nocgo.go
+++ b/clipboard_nocgo.go
@@ -5,7 +5,7 @@ package clipboard
 import "context"
 
 func initialize() error {
-	panic("clipboard: cannot use when CGO_ENABLED=0")
+	return errNoCgo
 }
 
 func read(t Format) (buf []byte, err error) {

--- a/clipboard_test.go
+++ b/clipboard_test.go
@@ -34,14 +34,9 @@ func TestClipboardInit(t *testing.T) {
 			t.Skip("Windows does not need to check for cgo")
 		}
 
-		defer func() {
-			if r := recover(); r != nil {
-				return
-			}
-			t.Fatalf("expect to fail when CGO_ENABLED=0")
-		}()
-
-		clipboard.Init()
+		if err := clipboard.Init(); !errors.Is(err, clipboard.ErrCgoDisabled) {
+			t.Fatalf("expect ErrCgoDisabled, got: %v", err)
+		}
 	})
 	t.Run("with-cgo", func(t *testing.T) {
 		if val, ok := os.LookupEnv("CGO_ENABLED"); ok && val == "0" {

--- a/export_test.go
+++ b/export_test.go
@@ -10,4 +10,5 @@ package clipboard
 var (
 	Debug          = debug
 	ErrUnavailable = errUnavailable
+	ErrCgoDisabled = errNoCgo
 )


### PR DESCRIPTION
## Summary
- provide `errNoCgo` and export it for tests
- return an error from `initialize()` when CGO is disabled
- update tests to expect `ErrCgoDisabled`

## Testing
- `go test ./...` *(fails: `Forbidden`)*

------
https://chatgpt.com/codex/tasks/task_e_68440f109ff48325984b0b2eadc8f526