### PR TITLE
Add Wayland note

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ accessing system clipboards, but here are a few details you might need to know.
 ### Dependency
 
 - macOS: require Cgo, no dependency
-- Linux: require X11 dev package. For instance, install `libx11-dev` or `xorg-dev` or `libX11-devel` to access X window system.
+ - Linux: require X11 dev package. For instance, install `libx11-dev` or `xorg-dev` or `libX11-devel` to access X window system.
+   Wayland sessions are currently unsupported; running under Wayland
+   typically requires an XWayland bridge and `DISPLAY` to be set.
 - Windows: no Cgo, no dependency
 - iOS/Android: collaborate with [`gomobile`](https://golang.org/x/mobile)
 


### PR DESCRIPTION
## Summary
- clarify Linux requirement and note that Wayland is unsupported

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684416e9a908832599d770a8eeb06d43