### PR TITLE
linux: fail fast after X11 display open failure, fall back to libx11.so.6

### DIFF
--- a/clipboard_linux.c
+++ b/clipboard_linux.c
@@ -64,24 +64,41 @@ int initX11() {
 	return 1;
 }
 
+// displayUnavailable remembers that opening the X11 display has already
+// failed, so later calls can fail fast instead of retrying the open on
+// every Write/Read/Watch. Without this, once Init fails (e.g. no DISPLAY
+// or no X server) each subsequent call repeats the open attempts and
+// blocks before returning the same error (see #85).
+static int displayUnavailable = 0;
+
+// openDisplay opens the X11 display, retrying a few times to tolerate a
+// transient race during startup. A persistent failure is cached so that
+// subsequent calls return immediately rather than retrying.
+Display* openDisplay() {
+	if (displayUnavailable) {
+		return NULL;
+	}
+	for (int i = 0; i < 42; i++) {
+		Display* d = (*P_XOpenDisplay)(0);
+		if (d != NULL) {
+			return d;
+		}
+	}
+	displayUnavailable = 1;
+	return NULL;
+}
+
 int clipboard_test() {
 	if (!initX11()) {
 		return -1;
 	}
 
-    Display* d = NULL;
-    for (int i = 0; i < 42; i++) {
-        d = (*P_XOpenDisplay)(0);
-        if (d == NULL) {
-            continue;
-        }
-        break;
-    }
-    if (d == NULL) {
-        return -1;
-    }
-    (*P_XCloseDisplay)(d);
-    return 0;
+	Display* d = openDisplay();
+	if (d == NULL) {
+		return -1;
+	}
+	(*P_XCloseDisplay)(d);
+	return 0;
 }
 
 // clipboard_write writes the given buf of size n as type typ.
@@ -93,14 +110,7 @@ int clipboard_write(char *typ, unsigned char *buf, size_t n, uintptr_t handle) {
 		return -1;
 	}
 
-    Display* d = NULL;
-    for (int i = 0; i < 42; i++) {
-        d = (*P_XOpenDisplay)(0);
-        if (d == NULL) {
-            continue;
-        }
-        break;
-    }
+    Display* d = openDisplay();
     if (d == NULL) {
         syncStatus(handle, -1);
         return -1;
@@ -231,14 +241,7 @@ unsigned long clipboard_read(char* typ, char **buf) {
 		return -1;
 	}
 
-    Display* d = NULL;
-    for (int i = 0; i < 42; i++) {
-        d = (*P_XOpenDisplay)(0);
-        if (d == NULL) {
-            continue;
-        }
-        break;
-    }
+    Display* d = openDisplay();
     if (d == NULL) {
         return -1;
     }

--- a/clipboard_linux.c
+++ b/clipboard_linux.c
@@ -39,10 +39,15 @@ int initX11() {
 		return 1;
 	}
 	libX11 = dlopen("libX11.so", RTLD_LAZY);
-	if (!libX11) {
-		return 0;
-	}
-	P_XOpenDisplay = (Display* (*)(int)) dlsym(libX11, "XOpenDisplay");
+    if (!libX11)
+    {
+        libX11 = dlopen("libX11.so.6", RTLD_LAZY);
+        if (!libX11)
+        {
+            return 0;
+        }
+    }
+    P_XOpenDisplay = (Display* (*)(int)) dlsym(libX11, "XOpenDisplay");
 	P_XCloseDisplay = (void (*)(Display*)) dlsym(libX11, "XCloseDisplay");
 	P_XDefaultRootWindow = (Window (*)(Display*)) dlsym(libX11, "XDefaultRootWindow");
 	P_XCreateSimpleWindow = (Window (*)(Display*, Window, int, int, int, int, int, int, int)) dlsym(libX11, "XCreateSimpleWindow");
@@ -84,6 +89,7 @@ int clipboard_test() {
 // if the write is availiable for reading.
 int clipboard_write(char *typ, unsigned char *buf, size_t n, uintptr_t handle) {
 	if (!initX11()) {
+        syncStatus(handle, -1);
 		return -1;
 	}
 


### PR DESCRIPTION
On X11, once opening the display fails (no DISPLAY or no X server), every
subsequent Write/Read/Watch repeated the open-retry loop before returning
the same error, adding a noticeable delay. Cache the failure and
short-circuit later calls so they fail fast via a single openDisplay()
helper.

Also try libx11.so.6 when the unversioned libX11.so is absent (common in
minimal containers/distros), and signal the Go side when libX11 cannot be
loaded at all so Write no longer blocks forever.

Fixes #85
