### PR TITLE
docs: document X11 clipboard ownership and platform caveats

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,23 @@ accessing system clipboards, but here are a few details you might need to know.
 - Windows: no Cgo, no dependency
 - iOS/Android: collaborate with [`gomobile`](https://golang.org/x/mobile)
 
+### Caveats
+
+- **Linux/X11 clipboard ownership.** On X11 the process that writes to
+  the clipboard *owns* the selection and serves its content to other
+  applications on demand. Once the writing process exits, the data is
+  gone — unless a clipboard manager is running to take over ownership.
+  In practice plain text is often retained because most clipboard
+  managers cache it, while larger image data is usually dropped. To keep
+  written data available after your program exits, keep the process
+  running (the channel returned by `Write` reports when the data is no
+  longer needed) or rely on a clipboard manager.
+- **Linux/X11 selection.** Only the `CLIPBOARD` selection (Ctrl+C/Ctrl+V)
+  is accessed; the `PRIMARY` selection (middle-click paste) is not
+  supported.
+- **Image format.** Image read/write assumes PNG-encoded data; other
+  encodings are undefined behavior.
+
 ### Screenshot
 
 In general, when you need test your implementation regarding images,

--- a/clipboard.go
+++ b/clipboard.go
@@ -52,6 +52,24 @@ clipboard data is changed, use the watcher API:
 		// print out clipboard data whenever it is changed
 		println(string(data))
 	}
+
+# Platform-specific caveats
+
+On Linux/X11 the clipboard follows the X11 selection-ownership model:
+the process that calls Write owns the selection and serves its content
+to other applications on demand. This means the written data only stays
+available for as long as the writing process is alive, unless a
+clipboard manager is running to take over ownership when the process
+exits. In practice plain text often survives because most clipboard
+managers cache it, whereas larger image data is usually dropped. To keep
+data available after your program exits, keep the process running (the
+channel returned by Write reports when the data is no longer needed) or
+rely on a clipboard manager.
+
+Also on Linux/X11, only the CLIPBOARD selection (the Ctrl+C/Ctrl+V
+clipboard) is accessed; the PRIMARY selection (middle-click paste) is
+not supported. Wayland sessions are not supported natively and require an
+XWayland bridge with DISPLAY set.
 */
 package clipboard // import "golang.design/x/clipboard"
 


### PR DESCRIPTION
## What

Documents the X11 selection-ownership model and a couple of other
platform-specific behaviors that have repeatedly surprised users.

## Why

On X11 the process that writes to the clipboard *owns* the selection and
must stay alive to serve its content; once it exits, the data is gone
unless a clipboard manager takes over. Text often appears to survive
(managers cache it) while images vanish — exactly the confusion reported
in #63. This isn't a bug, but it was undocumented.

## Changes

- `clipboard.go`: add a "Platform-specific caveats" section to the
  package doc covering X11 ownership/persistence, CLIPBOARD-only
  selection (no PRIMARY/middle-click), and the Wayland/XWayland note.
- `README.md`: add a **Caveats** subsection mirroring the above, plus the
  PNG-only image note, with a link to #63.

Docs only — no functional change. `go build ./...` and `go vet .` pass.

Refs #63
