### PR TITLE
windows: pass NULL handle to OpenClipboard in read path (#45)

### DIFF
--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -318,8 +318,13 @@ func read(t Format) (buf []byte, err error) {
 	}
 
 	// try again until open clipboard successed
+	//
+	// Pass a NULL (0) window handle explicitly: OpenClipboard expects an
+	// HWND argument, and omitting it leaves a garbage value on the stack
+	// under the 386 stdcall ABI, which makes the call spin here forever
+	// (see #45). The write path below already passes 0.
 	for {
-		r, _, _ = openClipboard.Call()
+		r, _, _ = openClipboard.Call(0)
 		if r == 0 {
 			continue
 		}


### PR DESCRIPTION
## What

Pass a NULL (`0`) window handle to `OpenClipboard` in the **read** path,
matching the write path which already does so.

## Why

`OpenClipboard(hWndNewOwner)` takes an `HWND` argument. The read path
called it with no argument:

```go
r, _, _ = openClipboard.Call()   // before
```

On amd64 the missing argument happens to be zero, so it works. On 386 the
stdcall ABI passes arguments on the stack, so omitting the handle leaves
a garbage value where the `HWND` should be — `OpenClipboard` keeps
failing and the retry loop spins forever, hanging the program on 32-bit
Windows. This matches the diagnosis in #45 (stuck in the `openClipboard`
loop in `clipboard_read`).

The write path (`clipboard_write`) already calls `openClipboard.Call(0)`,
so this just makes read consistent and aligns with the Win32 contract
(NULL associates the open clipboard with the current task).

## Testing

- Cross-compiles cleanly for both `windows/amd64` and `windows/386`
  (`GOOS=windows GOARCH=386 go build .`).
- `go vet` clean (the remaining `unsafe.Pointer` warnings are
  pre-existing and unrelated).

> Note: I could not add an automated regression test — the failure only
> manifests on 32-bit Windows, and CI has no 386 runner (the bug doesn't
> reproduce on amd64, where the existing tests already pass). The change
> is a one-line correctness fix mirroring the working write path. If you
> have access to a 386 environment, confirming the hang is gone would be
> valuable.

Fixes #45
