### PR TITLE
ci: local Linux test runner + windows/386 build check

### DIFF
--- a/.github/workflows/clipboard.yml
+++ b/.github/workflows/clipboard.yml
@@ -69,3 +69,22 @@ jobs:
       if: ${{ runner.os == 'Windows'}}
       run: |
         go test -v -covermode=atomic .
+
+  # The clipboard package previously hung on 32-bit Windows (#45). Make
+  # sure it keeps compiling for GOARCH=386. The runtime behavior cannot be
+  # exercised here because GitHub-hosted runners are amd64 only.
+  windows_386_build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        stable: 'false'
+        go-version: '1.24.x'
+    - name: Build for windows/386
+      env:
+        GOOS: windows
+        GOARCH: 386
+      run: |
+        go build .
+        go build ./cmd/gclip

--- a/hack/test-linux.sh
+++ b/hack/test-linux.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright 2026 The golang.design Initiative Authors.
+# All rights reserved. Use of this source code is governed
+# by a MIT license that can be found in the LICENSE file.
+#
+# Run the Linux/X11 test suite inside a container, so the cgo path can be
+# exercised from any host (e.g. macOS) without a local X server. Mirrors
+# what the GitHub Actions Linux job does: install libx11-dev, run the
+# tests under a virtual framebuffer with cgo on and off.
+#
+# Usage:
+#   hack/test-linux.sh            # auto-detect docker or podman
+#   GO_VERSION=1.24 hack/test-linux.sh
+#   CONTAINER=podman hack/test-linux.sh
+
+set -euo pipefail
+
+GO_VERSION="${GO_VERSION:-1.24}"
+
+# Pick a container runtime: explicit $CONTAINER, else docker, else podman.
+runtime="${CONTAINER:-}"
+if [ -z "${runtime}" ]; then
+	if command -v docker >/dev/null 2>&1; then
+		runtime="docker"
+	elif command -v podman >/dev/null 2>&1; then
+		runtime="podman"
+	else
+		echo "error: neither docker nor podman found on PATH" >&2
+		exit 1
+	fi
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+echo "Running Linux/X11 tests in ${runtime} (golang:${GO_VERSION})..."
+
+exec "${runtime}" run --rm -v "${repo_root}":/src -w /src "golang:${GO_VERSION}" bash -c '
+	set -e
+	apt-get update -qq >/dev/null
+	apt-get install -y -qq libx11-dev xvfb >/dev/null 2>&1
+	echo "--- go test (CGO_ENABLED=1, X11 path) ---"
+	CGO_ENABLED=1 xvfb-run -a go test -count=1 -covermode=atomic .
+	echo "--- go test (CGO_ENABLED=0, nocgo path) ---"
+	CGO_ENABLED=0 go test -count=1 -covermode=atomic .
+'


### PR DESCRIPTION
## What

Two additions to make platform testing easier:

1. **`hack/test-linux.sh`** — runs the Linux/X11 test suite (cgo on *and* off) inside a `golang` container under `xvfb`. Lets the cgo path be exercised from any host (including macOS) without a local X server, mirroring the CI Linux job. Auto-detects `docker`/`podman`; `GO_VERSION` and `CONTAINER` are overridable.

   ```
   ./hack/test-linux.sh
   ```
   Verified locally: `CGO_ENABLED=1` → `ok` (86.7% coverage), `CGO_ENABLED=0` → `ok` (64.0%).

2. **`windows_386_build` CI job** — the package previously hung on 32-bit Windows (#45); this guards against *compile* regressions for `GOARCH=386`. The runtime hang itself can't be reproduced on GitHub-hosted runners (amd64 only), which is called out in a comment.

## Notes

Docs/tooling + CI only; no functional change to the package. BSD CI coverage is handled separately on the BSD PR (#88), where the BSD sources live.
