### PR TITLE
all: degrade gracefully instead of panicking when CGO_ENABLED=0

### DIFF
--- a/clipboard.go
+++ b/clipboard.go
@@ -101,8 +101,12 @@ var (
 //		panic(err)
 //	}
 //
-// If Init returns an error, any subsequent Read/Write/Watch call
-// may result in an unrecoverable panic.
+// If Init returns an error because of a runtime dependency failure
+// (such as a missing libx11-dev), any subsequent Read/Write/Watch call
+// may result in an unrecoverable panic. In a CGO-disabled build
+// (CGO_ENABLED=0), Init returns an error and Read/Write/Watch degrade
+// gracefully instead of panicking: Read and Write return nil, and
+// Watch returns a closed channel.
 func Init() error {
 	initOnce.Do(func() {
 		initError = initialize()

--- a/clipboard_nocgo.go
+++ b/clipboard_nocgo.go
@@ -9,17 +9,23 @@ func initialize() error {
 }
 
 func read(t Format) (buf []byte, err error) {
-	panic("clipboard: cannot use when CGO_ENABLED=0")
+	return nil, errNoCgo
 }
 
 func readc(t string) ([]byte, error) {
-	panic("clipboard: cannot use when CGO_ENABLED=0")
+	return nil, errNoCgo
 }
 
 func write(t Format, buf []byte) (<-chan struct{}, error) {
-	panic("clipboard: cannot use when CGO_ENABLED=0")
+	return nil, errNoCgo
 }
 
 func watch(ctx context.Context, t Format) <-chan []byte {
-	panic("clipboard: cannot use when CGO_ENABLED=0")
+	// The clipboard is unavailable in a CGO-disabled build. Return a
+	// closed channel so that receivers observe completion immediately
+	// instead of blocking forever, consistent with the documented
+	// behavior when the given context is canceled.
+	ch := make(chan []byte)
+	close(ch)
+	return ch
 }

--- a/clipboard_test.go
+++ b/clipboard_test.go
@@ -301,36 +301,33 @@ func TestClipboardNoCgo(t *testing.T) {
 		t.Skip("Windows should always be tested")
 	}
 
+	// When CGO is disabled, the clipboard cannot function but the public
+	// API must degrade gracefully instead of panicking: Read/Write return
+	// nil and Watch returns a closed channel. See issue #93.
 	t.Run("Read", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r != nil {
-				return
-			}
-			t.Fatalf("expect to fail when CGO_ENABLED=0")
-		}()
-
-		clipboard.Read(clipboard.FmtText)
+		if got := clipboard.Read(clipboard.FmtText); got != nil {
+			t.Fatalf("expect nil when CGO_ENABLED=0, got: %v", got)
+		}
 	})
 
 	t.Run("Write", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r != nil {
-				return
-			}
-			t.Fatalf("expect to fail when CGO_ENABLED=0")
-		}()
-
-		clipboard.Write(clipboard.FmtText, []byte("dummy"))
+		if got := clipboard.Write(clipboard.FmtText, []byte("dummy")); got != nil {
+			t.Fatalf("expect nil when CGO_ENABLED=0, got non-nil channel")
+		}
 	})
 
 	t.Run("Watch", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r != nil {
-				return
+		changed := clipboard.Watch(context.TODO(), clipboard.FmtText)
+		if changed == nil {
+			t.Fatalf("expect a non-nil channel when CGO_ENABLED=0")
+		}
+		select {
+		case _, ok := <-changed:
+			if ok {
+				t.Fatalf("expect a closed channel when CGO_ENABLED=0")
 			}
-			t.Fatalf("expect to fail when CGO_ENABLED=0")
-		}()
-
-		clipboard.Watch(context.TODO(), clipboard.FmtText)
+		case <-time.After(time.Second):
+			t.Fatalf("expect a closed channel when CGO_ENABLED=0, but it blocked")
+		}
 	})
 }


### PR DESCRIPTION
Fixes #93.

## Problem

When `CGO_ENABLED=0`, `initialize()` was changed to return `errNoCgo` instead of panicking (#78, closing #57). But the remaining functions in `clipboard_nocgo.go` still panic:

```go
func read(t Format) (buf []byte, err error) { panic("clipboard: cannot use when CGO_ENABLED=0") }
func readc(t string) ([]byte, error)         { panic("...") }
func write(...) (<-chan struct{}, error)     { panic("...") }
func watch(...) <-chan []byte                { panic("...") }
```

So a caller who forgets to guard on `Init()` — the exact footgun in the original #57 report — gets a hard crash, even though `CGO_ENABLED=0` is known at **build time** via the `!cgo` tag and the public `Read`/`Write` API otherwise promises to return `nil` on failure.

## Fix

Degrade gracefully instead of panicking:

- `read`/`readc`/`write` → `return nil, errNoCgo`. The public `Read`/`Write` wrappers already swallow the error and return `nil`.
- `watch` → return a **closed** channel, so receivers observe completion immediately (`ok == false`) instead of blocking forever — consistent with the documented behavior when the context is canceled.

No behavior change for correct callers who check `Init()` first.

## Tests

`TestClipboardNoCgo` previously asserted that `Read`/`Write`/`Watch` **panic**; it now asserts the graceful behavior (`Read`/`Write` return `nil`, `Watch` yields a closed channel). Verified TDD-style on darwin: the rewritten test **fails** (panic propagates) against the old `clipboard_nocgo.go` and **passes** after the fix.

```
$ CGO_ENABLED=0 go test -run TestClipboardNoCgo -v .
--- PASS: TestClipboardNoCgo
    --- PASS: TestClipboardNoCgo/Read
    --- PASS: TestClipboardNoCgo/Write
    --- PASS: TestClipboardNoCgo/Watch
```

Also narrows the `Init()` doc comment to distinguish the build-time no-cgo path (now graceful) from runtime dependency failures on CGO-enabled platforms (which may still panic, unchanged).