### PR TITLE
darwin: read TIFF clipboard images as PNG

### DIFF
--- a/clipboard_darwin.m
+++ b/clipboard_darwin.m
@@ -28,7 +28,21 @@ unsigned int clipboard_read_image(void **out) {
 	NSPasteboard * pasteboard = [NSPasteboard generalPasteboard];
 	NSData *data = [pasteboard dataForType:NSPasteboardTypePNG];
 	if (data == nil) {
-		return 0;
+		// macOS stores copied images as TIFF by default (e.g. screenshots
+		// and "Copy Image" in many apps). Fall back to TIFF and transcode
+		// to PNG so callers always receive PNG data.
+		NSData *tiff = [pasteboard dataForType:NSPasteboardTypeTIFF];
+		if (tiff == nil) {
+			return 0;
+		}
+		NSBitmapImageRep *rep = [NSBitmapImageRep imageRepWithData:tiff];
+		if (rep == nil) {
+			return 0;
+		}
+		data = [rep representationUsingType:NSBitmapImageFileTypePNG properties:@{}];
+		if (data == nil) {
+			return 0;
+		}
 	}
 	NSUInteger siz = [data length];
 	*out = malloc(siz);

--- a/clipboard_tiff_darwin_test.go
+++ b/clipboard_tiff_darwin_test.go
@@ -1,0 +1,64 @@
+// Copyright 2021 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+//go:build darwin && !ios
+
+package clipboard_test
+
+import (
+	"bytes"
+	"image/png"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"golang.design/x/clipboard"
+)
+
+// TestReadImageTIFF verifies that reading an image works when the clipboard
+// only holds a TIFF representation, which is the default format macOS uses
+// for screenshots and the "Copy Image" command in many apps. Reading such a
+// clipboard previously returned nil because only PNG data was requested.
+func TestReadImageTIFF(t *testing.T) {
+	if val, ok := os.LookupEnv("CGO_ENABLED"); ok && val == "0" {
+		t.Skip("CGO_ENABLED is set to 0")
+	}
+
+	gold, err := os.ReadFile("tests/testdata/clipboard.png")
+	if err != nil {
+		t.Fatalf("failed to read gold file: %v", err)
+	}
+	want, err := png.Decode(bytes.NewReader(gold))
+	if err != nil {
+		t.Fatalf("gold file is not png encoded: %v", err)
+	}
+
+	// Convert the gold PNG to a TIFF file using the system sips tool.
+	tiff := filepath.Join(t.TempDir(), "clipboard.tiff")
+	if out, err := exec.Command("sips", "-s", "format", "tiff",
+		"tests/testdata/clipboard.png", "--out", tiff).CombinedOutput(); err != nil {
+		t.Skipf("sips unavailable: %v: %s", err, out)
+	}
+
+	// Place the TIFF, and only the TIFF, on the pasteboard via AppleScript.
+	script := `set the clipboard to (read (POSIX file "` + tiff + `") as TIFF picture)`
+	if out, err := exec.Command("osascript", "-e", script).CombinedOutput(); err != nil {
+		t.Skipf("osascript unavailable: %v: %s", err, out)
+	}
+
+	b := clipboard.Read(clipboard.FmtImage)
+	if b == nil {
+		t.Fatal("reading a TIFF-only clipboard returned nil, want PNG data")
+	}
+	got, err := png.Decode(bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("clipboard image is not png encoded: %v", err)
+	}
+	if got.Bounds() != want.Bounds() {
+		t.Fatalf("decoded image bounds = %v, want %v", got.Bounds(), want.Bounds())
+	}
+}


### PR DESCRIPTION
## Problem

On macOS, copied images are stored as TIFF by default — screenshots and the "Copy Image" command in many apps put a TIFF representation on the pasteboard, not PNG. `clipboard_read_image` only requested `NSPasteboardTypePNG` and returned `0` otherwise, so `clipboard.Read(clipboard.FmtImage)` returned `nil` for this very common case.

## Fix

Keep the existing PNG fast path; when PNG is absent, fall back to the TIFF representation and transcode it to PNG via `NSBitmapImageRep`. Callers keep receiving PNG bytes with no change on their side.

## Test

`clipboard_tiff_darwin_test.go` seeds a TIFF-only clipboard (via `sips` + `osascript`, skipping gracefully when those tools are unavailable) and asserts that `Read(FmtImage)` returns a valid PNG whose dimensions match the source image. The test fails without this fix and passes with it.

## Credit

This supersedes and combines the prior art from two existing PRs, with thanks to both authors:
- #47 by @dmbfm — the PNG-first / TIFF-fallback structure and concise `NSBitmapImageRep` transcode adopted here.
- #72 by @Lay523 — independently reported and fixed the same TIFF issue.

The key difference from #72 is that this keeps the PNG read as the fast path rather than reading TIFF unconditionally, which avoids regressing clipboards that contain PNG but no TIFF.