### PR TITLE
bsd: add clipboard support for FreeBSD, OpenBSD and NetBSD

### DIFF
--- a/.github/workflows/clipboard.yml
+++ b/.github/workflows/clipboard.yml
@@ -88,3 +88,37 @@ jobs:
       run: |
         go build .
         go build ./cmd/gclip
+
+  # The BSDs are not available as GitHub-hosted runners, so build the X11
+  # cgo path inside a VM to make sure it keeps compiling (see #55). The
+  # clipboard needs a running X server at runtime, which is out of scope
+  # for these build-only jobs.
+  freebsd_build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build on FreeBSD
+      uses: vmactions/freebsd-vm@v1
+      with:
+        usesh: true
+        prepare: |
+          pkg install -y go libX11
+        run: |
+          go version
+          CGO_ENABLED=1 go build .
+          CGO_ENABLED=1 go build ./cmd/gclip
+
+  openbsd_build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build on OpenBSD
+      uses: vmactions/openbsd-vm@v1
+      with:
+        usesh: true
+        prepare: |
+          pkg_add -I go
+        run: |
+          go version
+          CGO_ENABLED=1 go build .
+          CGO_ENABLED=1 go build ./cmd/gclip

--- a/clipboard_bsd.c
+++ b/clipboard_bsd.c
@@ -1,0 +1,16 @@
+// Copyright 2021 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+//go:build (openbsd || freebsd || netbsd) && !android
+
+// The BSD X11 clipboard implementation is identical to the Linux one.
+// Include it directly so the two never drift apart: any fix to the X11
+// logic in clipboard_linux.c applies to the BSDs automatically. The only
+// per-platform differences are the cgo flags, which live in the
+// respective clipboard_linux.go / clipboard_bsd.go files (Linux links
+// -ldl for dlopen, the BSDs ship it in libc and need the X11 include
+// path instead).
+#include "clipboard_linux.c"

--- a/clipboard_bsd.go
+++ b/clipboard_bsd.go
@@ -1,0 +1,182 @@
+// Copyright 2021 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+// NOTE: FreeBSD and OpenBSD are verified to build in CI. NetBSD shares
+// the same X11 implementation and is included on a best-effort basis, but
+// it is not covered by CI and has not been fully tested — the X11 header
+// prefix and runtime behavior there are unverified.
+
+//go:build (openbsd || freebsd || netbsd) && !android
+
+package clipboard
+
+/*
+// X11 headers live in different prefixes across the BSDs: OpenBSD ships
+// them in base under /usr/X11R6, FreeBSD installs the libX11 port under
+// /usr/local, and NetBSD uses /usr/X11R7 (base) or /usr/pkg (pkgsrc).
+// List them all; the compiler ignores include paths that do not exist.
+#cgo CFLAGS: -I/usr/X11R6/include -I/usr/local/include -I/usr/X11R7/include -I/usr/pkg/include
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+int clipboard_test();
+int clipboard_write(
+	char*          typ,
+	unsigned char* buf,
+	size_t         n,
+	uintptr_t      handle
+);
+unsigned long clipboard_read(char* typ, char **out);
+*/
+import "C"
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"runtime/cgo"
+	"time"
+	"unsafe"
+)
+
+var helpmsg = `%w: Failed to initialize the X11 display, and the clipboard package
+will not work properly. Install the following dependency may help:
+
+	apt install -y libx11-dev
+
+If the clipboard package is in an environment without a frame buffer,
+such as a cloud server, it may also be necessary to install xvfb:
+
+	apt install -y xvfb
+
+and initialize a virtual frame buffer:
+
+	Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+	export DISPLAY=:99.0
+
+Then this package should be ready to use.
+`
+
+func initialize() error {
+	ok := C.clipboard_test()
+	if ok != 0 {
+		return fmt.Errorf(helpmsg, errUnavailable)
+	}
+	return nil
+}
+
+func read(t Format) (buf []byte, err error) {
+	switch t {
+	case FmtText:
+		return readc("UTF8_STRING")
+	case FmtImage:
+		return readc("image/png")
+	}
+	return nil, errUnsupported
+}
+
+func readc(t string) ([]byte, error) {
+	ct := C.CString(t)
+	defer C.free(unsafe.Pointer(ct))
+
+	var data *C.char
+	n := C.clipboard_read(ct, &data)
+	switch C.long(n) {
+	case -1:
+		return nil, errUnavailable
+	case -2:
+		return nil, errUnsupported
+	}
+	if data == nil {
+		return nil, errUnavailable
+	}
+	defer C.free(unsafe.Pointer(data))
+	switch {
+	case n == 0:
+		return nil, nil
+	default:
+		return C.GoBytes(unsafe.Pointer(data), C.int(n)), nil
+	}
+}
+
+// write writes the given data to clipboard and
+// returns true if success or false if failed.
+func write(t Format, buf []byte) (<-chan struct{}, error) {
+	var s string
+	switch t {
+	case FmtText:
+		s = "UTF8_STRING"
+	case FmtImage:
+		s = "image/png"
+	}
+
+	start := make(chan int)
+	done := make(chan struct{}, 1)
+
+	go func() { // serve as a daemon until the ownership is terminated.
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+
+		cs := C.CString(s)
+		defer C.free(unsafe.Pointer(cs))
+
+		h := cgo.NewHandle(start)
+		var ok C.int
+		if len(buf) == 0 {
+			ok = C.clipboard_write(cs, nil, 0, C.uintptr_t(h))
+		} else {
+			ok = C.clipboard_write(cs, (*C.uchar)(unsafe.Pointer(&(buf[0]))), C.size_t(len(buf)), C.uintptr_t(h))
+		}
+		if ok != C.int(0) {
+			fmt.Fprintf(os.Stderr, "write failed with status: %d\n", int(ok))
+		}
+		done <- struct{}{}
+		close(done)
+	}()
+
+	status := <-start
+	if status < 0 {
+		return nil, errUnavailable
+	}
+	// wait until enter event loop
+	return done, nil
+}
+
+func watch(ctx context.Context, t Format) <-chan []byte {
+	recv := make(chan []byte, 1)
+	ti := time.NewTicker(time.Second)
+	last := Read(t)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				close(recv)
+				return
+			case <-ti.C:
+				b := Read(t)
+				if b == nil {
+					continue
+				}
+				if !bytes.Equal(last, b) {
+					recv <- b
+					last = b
+				}
+			}
+		}
+	}()
+	return recv
+}
+
+//export syncStatus
+func syncStatus(h uintptr, val int) {
+	v := cgo.Handle(h).Value().(chan int)
+	v <- val
+	cgo.Handle(h).Delete()
+}


### PR DESCRIPTION
Supersedes #88 — same work, on a base-repo branch so the BSD VM CI can run (the fork PR stopped spawning CI runs). Original author credited via `Co-authored-by`.

## What
- Build the X11 cgo implementation on the BSDs. `clipboard_bsd.c` includes `clipboard_linux.c` directly so the implementations never drift; per-OS cgo flags live in `clipboard_bsd.go` (X11 headers sit under different prefixes across the BSDs, and `dlopen` is in libc so no `-ldl`).
- Add `freebsd_build` and `openbsd_build` CI jobs (vmactions VMs) that compile the cgo X11 path.

## Verification
- **FreeBSD** ✅ and **OpenBSD** ✅ — `go build` succeeds in the VMs (verified in CI).
- **NetBSD** — included in the build tags on a **best-effort basis but NOT CI-tested**: a Go toolchain couldn't be reliably bootstrapped on the NetBSD CI VM, so there's no NetBSD job and the code there is unverified. This is noted in `clipboard_bsd.go`.

Updates #55 (FreeBSD/OpenBSD covered; NetBSD left for follow-up).
