### PR TITLE
test: drain watch channel until closed (fix #75 flake on Windows)

### DIFF
--- a/clipboard_test.go
+++ b/clipboard_test.go
@@ -279,13 +279,20 @@ loop:
 			lastRead = data
 		}
 	}
-	select {
-	case _, ok := <-changed:
-		if ok {
-			t.Fatalf("changed channel should be closed after ctx.Done")
+	// After the context is cancelled, watch must close the channel (per the
+	// Watch doc). A buffered value may still be pending, so drain until the
+	// channel is observed closed rather than asserting on a single receive.
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case _, ok := <-changed:
+			if !ok {
+				return // channel closed as documented
+			}
+			// A value was buffered before the close; keep draining.
+		case <-deadline:
+			t.Fatalf("changed channel was not closed after ctx cancellation")
 		}
-	case <-time.After(time.Second):
-		t.Fatalf("timeout waiting for changed to be closed")
 	}
 }
 


### PR DESCRIPTION
#75's new closure check used a single `<-changed` after ctx cancellation, but `changed` is buffered (cap 1) — a pending value could be received (ok=true) before the close, failing on Windows CI and turning `main` red.

Fix: drain the channel until it is observed closed (with a 2s timeout), which is what the `Watch` contract actually promises ("closed if the given context is canceled") and tolerates a buffered value delivered just before the close.

Verified locally on darwin (3×); the real check is the Windows job in CI.