### PR TITLE
test: add regression test for the linux TARGETS reply (#60)

### DIFF
--- a/.github/workflows/clipboard.yml
+++ b/.github/workflows/clipboard.yml
@@ -27,7 +27,7 @@ jobs:
       if: ${{ runner.os == 'Linux' }}
       run: |
         sudo apt update
-        sudo apt install -y xvfb libx11-dev x11-utils libegl1-mesa-dev libgles2-mesa-dev
+        sudo apt install -y xvfb libx11-dev x11-utils libegl1-mesa-dev libgles2-mesa-dev xclip
         Xvfb :0 -screen 0 1024x768x24 > /dev/null 2>&1 &
         # Wait for Xvfb
         MAX_ATTEMPTS=120 # About 60 seconds

--- a/clipboard_targets_linux_test.go
+++ b/clipboard_targets_linux_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+//go:build linux && !android
+
+package clipboard
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestClipboardTargetsReflectWrittenFormat is a regression test for #60.
+//
+// On a TARGETS request the selection owner must advertise the format it
+// actually holds. Before #60 the owner always replied with both UTF8_STRING
+// and image/png regardless of what was written, so after writing text a
+// requestor would still see image/png advertised (and get nothing if it
+// asked for it). This test writes text and then enumerates the clipboard's
+// advertised TARGETS via xclip, asserting they reflect the written format.
+//
+// It uses xclip as an independent X11 requestor because cgo cannot be used
+// directly from a _test.go file.
+func TestClipboardTargetsReflectWrittenFormat(t *testing.T) {
+	if _, err := exec.LookPath("xclip"); err != nil {
+		t.Skip("xclip not found; skipping TARGETS regression test")
+	}
+	if err := Init(); err != nil {
+		t.Skipf("clipboard unavailable: %v", err)
+	}
+
+	// Become the CLIPBOARD owner with text data.
+	if ch := Write(FmtText, []byte("targets-regression-#60")); ch == nil {
+		t.Fatal("Write returned nil channel")
+	}
+
+	// Ask the owner for the list of available targets. Retry briefly in case
+	// selection ownership has not settled yet.
+	var out []byte
+	var err error
+	for i := 0; i < 20; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		out, err = exec.CommandContext(ctx,
+			"xclip", "-selection", "clipboard", "-t", "TARGETS", "-o").Output()
+		cancel()
+		if err == nil && len(out) > 0 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("xclip TARGETS query failed: %v", err)
+	}
+
+	targets := map[string]bool{}
+	for _, name := range strings.Fields(string(out)) {
+		targets[name] = true
+	}
+	t.Logf("advertised TARGETS: %v", targets)
+
+	if !targets["UTF8_STRING"] {
+		t.Errorf("TARGETS should advertise UTF8_STRING after writing text; got %v", targets)
+	}
+	if targets["image/png"] {
+		t.Errorf("TARGETS must not advertise image/png after writing text only (regression #60); got %v", targets)
+	}
+}

--- a/hack/test-linux.sh
+++ b/hack/test-linux.sh
@@ -37,7 +37,7 @@ echo "Running Linux/X11 tests in ${runtime} (golang:${GO_VERSION})..."
 exec "${runtime}" run --rm -v "${repo_root}":/src -w /src "golang:${GO_VERSION}" bash -c '
 	set -e
 	apt-get update -qq >/dev/null
-	apt-get install -y -qq libx11-dev xvfb >/dev/null 2>&1
+	apt-get install -y -qq libx11-dev xvfb xclip >/dev/null 2>&1
 	echo "--- go test (CGO_ENABLED=1, X11 path) ---"
 	CGO_ENABLED=1 xvfb-run -a go test -count=1 -covermode=atomic .
 	echo "--- go test (CGO_ENABLED=0, nocgo path) ---"


### PR DESCRIPTION
Adds the regression test that #60 should have shipped with.

The fix in #60 made the X11 selection owner advertise the format it actually holds on a `TARGETS` request (instead of always claiming both `UTF8_STRING` and `image/png`). This test writes text, then enumerates the clipboard's advertised `TARGETS` via `xclip` (an independent X11 requestor — cgo can't be used from a `_test.go` file) and asserts the list contains `UTF8_STRING` but **not** `image/png`.

**Verified both directions in a Linux container:**
- against the pre-#60 reply `{UTF8_STRING, image/png}` → test **fails** (`map[UTF8_STRING:true image/png:true]`)
- with the fix `{TARGETS, target}` → test **passes**

`xclip` added to the CI Linux deps and `hack/test-linux.sh`. The test skips if `xclip` is absent or the clipboard is unavailable (e.g. `CGO_ENABLED=0`).

Refs #60