### PR TITLE
windows: fix image corruption from 16-bit channel truncation

### DIFF
--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -220,56 +220,7 @@ func writeImage(buf []byte) error {
 		return fmt.Errorf("input bytes is not PNG encoded: %w", err)
 	}
 
-	offset := unsafe.Sizeof(bitmapV5Header{})
-	width := img.Bounds().Dx()
-	height := img.Bounds().Dy()
-	imageSize := 4 * width * height
-
-	data := make([]byte, int(offset)+imageSize)
-	for y := 0; y < height; y++ {
-		for x := 0; x < width; x++ {
-			idx := int(offset) + 4*(y*width+x)
-			r, g, b, a := img.At(x, height-1-y).RGBA()
-			data[idx+2] = uint8(r)
-			data[idx+1] = uint8(g)
-			data[idx+0] = uint8(b)
-			data[idx+3] = uint8(a)
-		}
-	}
-
-	info := bitmapV5Header{}
-	info.Size = uint32(offset)
-	info.Width = int32(width)
-	info.Height = int32(height)
-	info.Planes = 1
-	info.Compression = 0 // BI_RGB
-	info.SizeImage = uint32(4 * info.Width * info.Height)
-	info.RedMask = 0xff0000 // default mask
-	info.GreenMask = 0xff00
-	info.BlueMask = 0xff
-	info.AlphaMask = 0xff000000
-	info.BitCount = 32 // we only deal with 32 bpp at the moment.
-	// Use calibrated RGB values as Go's image/png assumes linear color space.
-	// Other options:
-	// - LCS_CALIBRATED_RGB = 0x00000000
-	// - LCS_sRGB = 0x73524742
-	// - LCS_WINDOWS_COLOR_SPACE = 0x57696E20
-	// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wmf/eb4bbd50-b3ce-4917-895c-be31f214797f
-	info.CSType = 0x73524742
-	// Use GL_IMAGES for GamutMappingIntent
-	// Other options:
-	// - LCS_GM_ABS_COLORIMETRIC = 0x00000008
-	// - LCS_GM_BUSINESS = 0x00000001
-	// - LCS_GM_GRAPHICS = 0x00000002
-	// - LCS_GM_IMAGES = 0x00000004
-	// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wmf/9fec0834-607d-427d-abd5-ab240fb0db38
-	info.Intent = 4 // LCS_GM_IMAGES
-
-	infob := make([]byte, int(unsafe.Sizeof(info)))
-	for i, v := range *(*[unsafe.Sizeof(info)]byte)(unsafe.Pointer(&info)) {
-		infob[i] = v
-	}
-	copy(data[:], infob[:])
+	data := imageToDIB(img)
 
 	hMem, _, err := gAlloc.Call(gmemMoveable,
 		uintptr(len(data)*int(unsafe.Sizeof(data[0]))))
@@ -442,39 +393,6 @@ const (
 	cFmtDataObject = 49161 // Shift+Win+s, returned from enumClipboardFormats
 	gmemMoveable   = 0x0002
 )
-
-// BITMAPV5Header structure, see:
-// https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapv5header
-type bitmapV5Header struct {
-	Size          uint32
-	Width         int32
-	Height        int32
-	Planes        uint16
-	BitCount      uint16
-	Compression   uint32
-	SizeImage     uint32
-	XPelsPerMeter int32
-	YPelsPerMeter int32
-	ClrUsed       uint32
-	ClrImportant  uint32
-	RedMask       uint32
-	GreenMask     uint32
-	BlueMask      uint32
-	AlphaMask     uint32
-	CSType        uint32
-	Endpoints     struct {
-		CiexyzRed, CiexyzGreen, CiexyzBlue struct {
-			CiexyzX, CiexyzY, CiexyzZ int32 // FXPT2DOT30
-		}
-	}
-	GammaRed    uint32
-	GammaGreen  uint32
-	GammaBlue   uint32
-	Intent      uint32
-	ProfileData uint32
-	ProfileSize uint32
-	Reserved    uint32
-}
 
 type bitmapHeader struct {
 	Size          uint32

--- a/dib.go
+++ b/dib.go
@@ -1,0 +1,112 @@
+// Copyright 2021 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+package clipboard
+
+import (
+	"image"
+	"unsafe"
+)
+
+// BITMAPV5Header structure, see:
+// https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapv5header
+//
+// This lives in an untagged file (rather than clipboard_windows.go) so the
+// pure pixel-packing logic in imageToDIB can be unit tested on any platform.
+type bitmapV5Header struct {
+	Size          uint32
+	Width         int32
+	Height        int32
+	Planes        uint16
+	BitCount      uint16
+	Compression   uint32
+	SizeImage     uint32
+	XPelsPerMeter int32
+	YPelsPerMeter int32
+	ClrUsed       uint32
+	ClrImportant  uint32
+	RedMask       uint32
+	GreenMask     uint32
+	BlueMask      uint32
+	AlphaMask     uint32
+	CSType        uint32
+	Endpoints     struct {
+		CiexyzRed, CiexyzGreen, CiexyzBlue struct {
+			CiexyzX, CiexyzY, CiexyzZ int32 // FXPT2DOT30
+		}
+	}
+	GammaRed    uint32
+	GammaGreen  uint32
+	GammaBlue   uint32
+	Intent      uint32
+	ProfileData uint32
+	ProfileSize uint32
+	Reserved    uint32
+}
+
+// imageToDIB converts an image into a CF_DIBV5 memory block: a
+// BITMAPV5HEADER followed by 32bpp, bottom-up, BGRA pixel data, matching
+// what Windows expects from SetClipboardData(CF_DIBV5, ...).
+func imageToDIB(img image.Image) []byte {
+	offset := unsafe.Sizeof(bitmapV5Header{})
+	width := img.Bounds().Dx()
+	height := img.Bounds().Dy()
+	imageSize := 4 * width * height
+
+	data := make([]byte, int(offset)+imageSize)
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			idx := int(offset) + 4*(y*width+x)
+			// DIB scanlines are stored bottom-up.
+			r, g, b, a := img.At(x, height-1-y).RGBA()
+			// color.Color.RGBA() returns 16-bit (0-0xffff) channels; take
+			// the high byte for 8-bit BGRA. Using uint8(r) here would keep
+			// the low byte, which is correct only for 8-bit-sourced images
+			// (where high byte == low byte) and produces garbage for 16-bit
+			// images such as those png.Encode emits for a decoded JPEG. See #48.
+			data[idx+2] = uint8(r >> 8)
+			data[idx+1] = uint8(g >> 8)
+			data[idx+0] = uint8(b >> 8)
+			data[idx+3] = uint8(a >> 8)
+		}
+	}
+
+	info := bitmapV5Header{}
+	info.Size = uint32(offset)
+	info.Width = int32(width)
+	info.Height = int32(height)
+	info.Planes = 1
+	info.Compression = 0 // BI_RGB
+	info.SizeImage = uint32(4 * info.Width * info.Height)
+	info.RedMask = 0xff0000 // default mask
+	info.GreenMask = 0xff00
+	info.BlueMask = 0xff
+	info.AlphaMask = 0xff000000
+	info.BitCount = 32 // we only deal with 32 bpp at the moment.
+	// Use calibrated RGB values as Go's image/png assumes linear color space.
+	// Other options:
+	// - LCS_CALIBRATED_RGB = 0x00000000
+	// - LCS_sRGB = 0x73524742
+	// - LCS_WINDOWS_COLOR_SPACE = 0x57696E20
+	// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wmf/eb4bbd50-b3ce-4917-895c-be31f214797f
+	info.CSType = 0x73524742
+	// Use GL_IMAGES for GamutMappingIntent
+	// Other options:
+	// - LCS_GM_ABS_COLORIMETRIC = 0x00000008
+	// - LCS_GM_BUSINESS = 0x00000001
+	// - LCS_GM_GRAPHICS = 0x00000002
+	// - LCS_GM_IMAGES = 0x00000004
+	// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wmf/9fec0834-607d-427d-abd5-ab240fb0db38
+	info.Intent = 4 // LCS_GM_IMAGES
+
+	infob := make([]byte, int(unsafe.Sizeof(info)))
+	for i, v := range *(*[unsafe.Sizeof(info)]byte)(unsafe.Pointer(&info)) {
+		infob[i] = v
+	}
+	copy(data[:], infob[:])
+
+	return data
+}

--- a/dib_test.go
+++ b/dib_test.go
@@ -1,0 +1,102 @@
+// Copyright 2021 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+package clipboard
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
+	"testing"
+	"unsafe"
+)
+
+// pixelAt returns the BGRA bytes imageToDIB stored for source pixel (x, y).
+func pixelAt(dib []byte, width, height, x, y int) (b, g, r, a byte) {
+	offset := int(unsafe.Sizeof(bitmapV5Header{}))
+	// imageToDIB writes scanlines bottom-up, so source row y lands at
+	// DIB row (height-1-y).
+	idx := offset + 4*((height-1-y)*width+x)
+	return dib[idx+0], dib[idx+1], dib[idx+2], dib[idx+3]
+}
+
+// TestImageToDIB16Bit guards against the 16-bit truncation bug in #48: a
+// JPEG decoded then re-encoded to PNG becomes a 16-bit (RGBA64) image, whose
+// channels must be down-sampled by taking the high byte. The old code used
+// uint8(r), keeping the low byte, which corrupted every such image.
+func TestImageToDIB16Bit(t *testing.T) {
+	img := image.NewRGBA64(image.Rect(0, 0, 2, 1))
+	// Opaque, 16-bit values whose low byte differs from the high byte, so
+	// uint8(v) and uint8(v>>8) disagree.
+	img.SetRGBA64(0, 0, color.RGBA64{R: 0x1234, G: 0x5678, B: 0x9abc, A: 0xffff})
+	img.SetRGBA64(1, 0, color.RGBA64{R: 0xaabb, G: 0xccdd, B: 0xeeff, A: 0xffff})
+
+	dib := imageToDIB(img)
+
+	for _, tc := range []struct {
+		x          int
+		r, g, b, a byte
+	}{
+		{0, 0x12, 0x56, 0x9a, 0xff},
+		{1, 0xaa, 0xcc, 0xee, 0xff},
+	} {
+		b, g, r, a := pixelAt(dib, 2, 1, tc.x, 0)
+		if r != tc.r || g != tc.g || b != tc.b || a != tc.a {
+			t.Errorf("pixel (%d,0): got BGRA=%#x,%#x,%#x,%#x, want R=%#x G=%#x B=%#x A=%#x",
+				tc.x, b, g, r, a, tc.r, tc.g, tc.b, tc.a)
+		}
+	}
+}
+
+// TestImageToDIBJPEGPNGPipeline reproduces the exact pipeline from #48: an
+// image is encoded to JPEG, decoded (yielding *image.YCbCr), re-encoded to
+// PNG (which emits 16-bit truecolor for a non-RGBA color model), then decoded
+// again before being written to the clipboard. Every DIB pixel must match the
+// high byte of the corresponding decoded pixel; the pre-fix code did not.
+func TestImageToDIBJPEGPNGPipeline(t *testing.T) {
+	const w, h = 32, 24
+	base := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			base.Set(x, y, color.RGBA{R: uint8(x * 7), G: uint8(y * 9), B: 128, A: 255})
+		}
+	}
+
+	var jb bytes.Buffer
+	if err := jpeg.Encode(&jb, base, &jpeg.Options{Quality: 90}); err != nil {
+		t.Fatal(err)
+	}
+	jimg, err := jpeg.Decode(&jb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := jimg.(*image.YCbCr); !ok {
+		t.Fatalf("expected JPEG to decode to *image.YCbCr, got %T", jimg)
+	}
+
+	var pb bytes.Buffer
+	if err := png.Encode(&pb, jimg); err != nil {
+		t.Fatal(err)
+	}
+	pimg, err := png.Decode(&pb)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dib := imageToDIB(pimg)
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			wr, wg, wb, wa := pimg.At(x, y).RGBA()
+			b, g, r, a := pixelAt(dib, w, h, x, y)
+			if r != uint8(wr>>8) || g != uint8(wg>>8) || b != uint8(wb>>8) || a != uint8(wa>>8) {
+				t.Fatalf("pixel (%d,%d): got BGRA=%#x,%#x,%#x,%#x, want R=%#x G=%#x B=%#x A=%#x",
+					x, y, b, g, r, a, uint8(wr>>8), uint8(wg>>8), uint8(wb>>8), uint8(wa>>8))
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Fixes #48. On Windows, writing an image to the clipboard corrupts it whenever the source image has 16-bit channels. The reporter's exact pipeline triggers this:

1. `image.Decode` of a JPEG returns an `*image.YCbCr`.
2. `png.Encode` of a YCbCr image (a non-RGBA color model) emits **16-bit** truecolor PNG.
3. `png.Decode` returns an `*image.RGBA64`.

`writeImage` then packed pixels with:

```go
r, g, b, a := img.At(x, height-1-y).RGBA() // 16-bit (0-0xffff) channels
data[idx+2] = uint8(r)                     // keeps the LOW byte
```

`color.Color.RGBA()` returns 16-bit channel values. `uint8(r)` keeps the low byte, which is correct only for 8-bit-sourced images (where `RGBA()` expands `v` to `v*0x101`, so high byte == low byte). For 16-bit images it stores garbage — every pixel is wrong. This matches the "file is fine, clipboard is corrupt" symptom in the issue: the file is the untouched PNG, only the clipboard path runs the lossy packing.

## Fix

Take the high byte (`uint8(r >> 8)`).

## Why the existing test missed it

The image round-trip test uses an **8-bit** fixture (clipboard.png), where low byte == high byte, *and* it writes then reads entirely within the library, where both sides apply the same `uint8()` truncation — so the error cancels out and the test passes regardless.

## Testing

The pure `image.Image -> DIB` conversion is extracted into an untagged `dib.go` so it can be unit tested on **any** platform (the buggy code is `//go:build windows`, so a Windows-only test couldn't be verified on a non-Windows dev machine). New tests in `dib_test.go`:

- `TestImageToDIB16Bit` — explicit 16-bit `RGBA64` pixels with known expected BGRA bytes.
- `TestImageToDIBJPEGPNGPipeline` — reproduces the issue's full JPEG -> PNG -> DIB pipeline.

Both **fail without this fix** and pass with it. Full suite passes.

## Scope / follow-up

This fixes the reported (opaque) case completely. A **separate** latent issue remains for images with transparency: `writeImage` stores premultiplied `RGBA()` values under a header that declares straight alpha (`AlphaMask`). That is out of scope here and will be filed separately.
