### PR TITLE
docs: clarify Write()'s returned channel semantics

### DIFF
--- a/clipboard.go
+++ b/clipboard.go
@@ -149,9 +149,14 @@ func Read(t Format) []byte {
 }
 
 // Write writes a given buffer to the clipboard in a specified format.
-// Write returned a receive-only channel can receive an empty struct
-// as a signal, which indicates the clipboard has been overwritten from
-// this write.
+//
+// The data is on the clipboard as soon as Write returns; consuming the
+// returned channel is optional. That channel receives a single empty
+// struct, and is then closed, only when the clipboard is later overwritten
+// by another writer (detected via the platform clipboard sequence number).
+// If nothing else ever overwrites the clipboard, the channel never fires —
+// so do not block on it expecting it to report that this write completed.
+//
 // If format t indicates an image, then the given buf assumes
 // the image data is PNG encoded.
 func Write(t Format, buf []byte) <-chan struct{} {


### PR DESCRIPTION
Closes #106.

## What

Documentation-only clarification of `Write`'s returned channel. No behavior change.

The previous wording — "indicates the clipboard has been overwritten from this write" — reads as "the write completed", so users block on `<-clipboard.Write(...)` and see an apparent hang (reported in #48). The channel actually fires only when the clipboard is **later overwritten by another writer**, and may legitimately never fire.

## New doc

```
// Write writes a given buffer to the clipboard in a specified format.
//
// The data is on the clipboard as soon as Write returns; consuming the
// returned channel is optional. That channel receives a single empty
// struct, and is then closed, only when the clipboard is later overwritten
// by another writer (detected via the platform clipboard sequence number).
// If nothing else ever overwrites the clipboard, the channel never fires —
// so do not block on it expecting it to report that this write completed.
//
// If format t indicates an image, then the given buf assumes
// the image data is PNG encoded.
```
