### PR TITLE
windows: store straight (non-premultiplied) alpha for images

### DIFF
--- a/dib.go
+++ b/dib.go
@@ -8,6 +8,7 @@ package clipboard
 
 import (
 	"image"
+	"image/color"
 	"unsafe"
 )
 
@@ -61,16 +62,20 @@ func imageToDIB(img image.Image) []byte {
 		for x := 0; x < width; x++ {
 			idx := int(offset) + 4*(y*width+x)
 			// DIB scanlines are stored bottom-up.
-			r, g, b, a := img.At(x, height-1-y).RGBA()
-			// color.Color.RGBA() returns 16-bit (0-0xffff) channels; take
-			// the high byte for 8-bit BGRA. Using uint8(r) here would keep
-			// the low byte, which is correct only for 8-bit-sourced images
-			// (where high byte == low byte) and produces garbage for 16-bit
-			// images such as those png.Encode emits for a decoded JPEG. See #48.
-			data[idx+2] = uint8(r >> 8)
-			data[idx+1] = uint8(g >> 8)
-			data[idx+0] = uint8(b >> 8)
-			data[idx+3] = uint8(a >> 8)
+			//
+			// The header declares straight (non-premultiplied) alpha via
+			// AlphaMask, so store straight-alpha 8-bit BGRA. Going through
+			// color.NRGBAModel both un-premultiplies (color.Color.RGBA()
+			// returns alpha-premultiplied values) and down-samples 16-bit
+			// channels to 8-bit by taking the high byte. This supersedes the
+			// uint8(r>>8) fix from #48 and additionally corrects transparent
+			// images, which previously stored premultiplied (darkened) RGB.
+			// See #105.
+			c := color.NRGBAModel.Convert(img.At(x, height-1-y)).(color.NRGBA)
+			data[idx+2] = c.R
+			data[idx+1] = c.G
+			data[idx+0] = c.B
+			data[idx+3] = c.A
 		}
 	}
 

--- a/dib_test.go
+++ b/dib_test.go
@@ -53,6 +53,24 @@ func TestImageToDIB16Bit(t *testing.T) {
 	}
 }
 
+// TestImageToDIBStraightAlpha guards against #105: the DIB header declares
+// straight alpha, so transparent pixels must be stored non-premultiplied.
+// The previous code stored color.Color.RGBA()'s premultiplied (darkened) RGB.
+func TestImageToDIBStraightAlpha(t *testing.T) {
+	img := image.NewNRGBA(image.Rect(0, 0, 1, 1))
+	// Semi-transparent: straight RGB are 200,100,50; premultiplied would be
+	// roughly halved (~100,50,25), so the two storage choices clearly differ.
+	want := color.NRGBA{R: 200, G: 100, B: 50, A: 128}
+	img.SetNRGBA(0, 0, want)
+
+	dib := imageToDIB(img)
+	b, g, r, a := pixelAt(dib, 1, 1, 0, 0)
+	if r != want.R || g != want.G || b != want.B || a != want.A {
+		t.Errorf("got BGRA=%d,%d,%d,%d, want straight R=%d G=%d B=%d A=%d",
+			b, g, r, a, want.R, want.G, want.B, want.A)
+	}
+}
+
 // TestImageToDIBJPEGPNGPipeline reproduces the exact pipeline from #48: an
 // image is encoded to JPEG, decoded (yielding *image.YCbCr), re-encoded to
 // PNG (which emits 16-bit truecolor for a non-RGBA color model), then decoded


### PR DESCRIPTION
Addresses #105. **Draft — parked pending a one-time human paste test on real Windows** (see checklist below). Do not merge until that confirms the target.

## Problem

The `CF_DIBV5` header declares **straight** (non-premultiplied) alpha (`AlphaMask = 0xff000000`), but the pixel packing stored `color.Color.RGBA()`'s **premultiplied** RGB. Opaque images (the #48 case, fixed in #102) are unaffected; semi-transparent pixels were stored with darkened RGB.

## Change in this PR (write side only)

`imageToDIB` now converts each pixel through `color.NRGBAModel`, storing straight-alpha 8-bit BGRA. Supersedes #102's `uint8(r>>8)` (opaque results identical). `TestImageToDIBStraightAlpha` asserts the stored bytes are straight; it **fails on the old premultiplied packing** and passes here.

## Why this is parked, not finished

1. **The target is unconfirmed.** That straight alpha is what Windows consumers expect was inferred from `golang.org/x/image/bmp`, **not** from a real Windows app. Only a human paste test can settle it (below).
2. **CI cannot settle it.**
   - The byte-level test (`TestImageToDIBStraightAlpha`) is untagged and **already runs on the `windows-latest` job** — so the "are the stored bytes straight" question is already tested on Windows CI. But that only verifies the bytes are straight, not that straight is *correct*.
   - An OS `Write -> Read` round-trip **cannot detect this bug**: the old write premultiplies and the old read + `png.Encode` un-premultiplies, so they cancel and the round-trip passes either way.
   - `System.Windows.Forms.Clipboard.GetImage()` flattens alpha through an HBITMAP and is an unreliable oracle.
3. **Read side is coupled and intentionally untouched here.** Changing only the write side makes the library's own round-trip lossy for mid-range transparent colors (write straight, read-as-premultiplied over-brightens on encode). Fixing `readImage` to read straight (`NRGBA`) has its **own** ground-truth question — how to interpret DIBs produced by *other* apps — which the same paste test must answer. Both sides should be decided together, after the test.

## Manual paste-test checklist (run on real Windows)

Goal: determine whether Windows apps expect **straight** or **premultiplied** alpha in `CF_DIBV5`.

1. Build a tiny writer with a **mid-range** test image — avoid 0/255 channels, which saturate and hide the difference. Suggested pixels:
   - opaque reference swatch: `NRGBA{180, 120, 60, 255}`
   - same color at half alpha: `NRGBA{180, 120, 60, 128}` (premultiplied storage would darken RGB to ~`90,60,30`)
   ```go
   clipboard.Init()
   // build the image above, png.Encode it into buf
   <-clipboard.Write(clipboard.FmtImage, buf) // keep process alive so the data stays on the clipboard
   ```
2. Open the **same PNG directly** in an image viewer over a white and a black background — this is ground truth for how it should look.
3. Paste the clipboard image into each of: **mspaint**, **Word/PowerPoint**, a **browser** (e.g. an image field), **GIMP/Photoshop**, **Slack/Discord**. Paste over both white and dark backgrounds where possible.
4. Record per app: do the semi-transparent regions match ground truth (**straight**), or are they darkened toward black (**premultiplied**), or is alpha dropped entirely (**opaque**)?
5. Decide:
   - **Mostly straight** -> this PR's direction is right; also update `readImage` to `NRGBA` for round-trip consistency, then un-draft.
   - **Mostly premultiplied** -> revert this PR; the original premultiplied storage was correct and #48 was purely the 16-bit issue.
   - **Alpha dropped** -> document that transparency is not preserved on Windows; no code change.

Paste the findings into #105 and we'll finalize from there.
