### PR TITLE
linux: don't let X protocol errors crash the host process (#61)

### DIFF
--- a/clipboard_errorhandler_linux_test.go
+++ b/clipboard_errorhandler_linux_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+//go:build linux && !android && cgo
+
+package clipboard
+
+import "testing"
+
+// TestX11ProtocolErrorDoesNotCrash is a regression test for #61: an X11
+// protocol error must not terminate the host process.
+//
+// triggerProtocolError issues a deliberately invalid X request (a BadWindow on
+// X_ChangeProperty, the same opcode that crashed in #61). Without the
+// XSetErrorHandler installed in initX11, Xlib's default handler would print the
+// error and call exit(1) — which would kill this test binary and fail the run.
+// With the handler installed, the error is swallowed and the call returns,
+// proving the process survives.
+func TestX11ProtocolErrorDoesNotCrash(t *testing.T) {
+	if err := Init(); err != nil {
+		t.Skipf("clipboard unavailable: %v", err)
+	}
+	if got := triggerProtocolError(); got != 0 {
+		t.Fatalf("triggerProtocolError() = %d, want 0 (X display unavailable?)", got)
+	}
+	// Reaching here means the process survived the protocol error.
+}

--- a/clipboard_linux.c
+++ b/clipboard_linux.c
@@ -33,6 +33,19 @@ int (*P_XGetWindowProperty) (Display*, Window, Atom, long, long, Bool, Atom, Ato
 void (*P_XFree) (void*);
 void (*P_XDeleteProperty) (Display*, Window, Atom);
 void (*P_XConvertSelection)(Display*, Atom, Atom, Atom, Window, Time);
+int (*P_XSetErrorHandler)(int (*)(Display*, XErrorEvent*));
+int (*P_XSync)(Display*, int);
+
+// ignoreXError swallows asynchronous X11 protocol errors instead of letting
+// Xlib's default handler terminate the whole process. On a pure Wayland
+// session the X selection can be served against an invalid requestor window,
+// producing a BadWindow error on X_ChangeProperty; without this handler Xlib
+// would print the error and call exit(1), crashing the host program (see #61).
+int ignoreXError(Display* d, XErrorEvent* e) {
+	(void)d;
+	(void)e;
+	return 0; // the return value is ignored by Xlib
+}
 
 int initX11() {
 	if (libX11) {
@@ -61,6 +74,15 @@ int initX11() {
 	P_XFree = (void (*)(void*)) dlsym(libX11, "XFree");
 	P_XDeleteProperty = (void (*)(Display*, Window, Atom)) dlsym(libX11, "XDeleteProperty");
 	P_XConvertSelection = (void (*)(Display*, Atom, Atom, Atom, Window, Time)) dlsym(libX11, "XConvertSelection");
+	P_XSetErrorHandler = (int (*)(int (*)(Display*, XErrorEvent*))) dlsym(libX11, "XSetErrorHandler");
+	P_XSync = (int (*)(Display*, int)) dlsym(libX11, "XSync");
+
+	// Install a handler so an asynchronous protocol error can never abort the
+	// host process (see #61). This is process-global, as Xlib offers no
+	// per-display protocol error handler.
+	if (P_XSetErrorHandler != NULL) {
+		(*P_XSetErrorHandler)(ignoreXError);
+	}
 	return 1;
 }
 
@@ -102,6 +124,31 @@ int clipboard_test() {
 	Display* d = openDisplay();
 	if (d == NULL) {
 		return -1;
+	}
+	(*P_XCloseDisplay)(d);
+	return 0;
+}
+
+// clipboard_trigger_protocol_error deliberately issues an invalid X request to
+// verify that the error handler installed by initX11 keeps the process alive.
+// It returns 0 if the process survived the resulting protocol error, or a
+// negative value if the X display is unavailable. Without the handler, Xlib's
+// default handler would call exit(1). Exposed only for the #61 regression test.
+int clipboard_trigger_protocol_error() {
+	if (!initX11()) {
+		return -1;
+	}
+	Display* d = openDisplay();
+	if (d == NULL) {
+		return -1;
+	}
+	Atom prop = (*P_XInternAtom)(d, "GOLANG_DESIGN_ERRTEST", 0);
+	unsigned char val = 1;
+	// 0xffffffff is not a valid window, so this yields a BadWindow protocol
+	// error on X_ChangeProperty (the same opcode that crashed in #61).
+	(*P_XChangeProperty)(d, (Window)0xffffffff, prop, XA_ATOM, 8, PropModeReplace, &val, 1);
+	if (P_XSync != NULL) {
+		(*P_XSync)(d, 0); // flush so the error is delivered to our handler
 	}
 	(*P_XCloseDisplay)(d);
 	return 0;

--- a/clipboard_linux.go
+++ b/clipboard_linux.go
@@ -23,6 +23,7 @@ int clipboard_write(
 	uintptr_t      handle
 );
 unsigned long clipboard_read(char* typ, char **out);
+int clipboard_trigger_protocol_error();
 */
 import "C"
 import (
@@ -169,4 +170,12 @@ func syncStatus(h uintptr, val int) {
 	v := cgo.Handle(h).Value().(chan int)
 	v <- val
 	cgo.Handle(h).Delete()
+}
+
+// triggerProtocolError deliberately provokes an X11 protocol error to verify
+// that the handler installed by initX11 keeps the process alive (see #61). It
+// returns 0 if the process survived, or a negative value if X is unavailable.
+// Exposed only for the regression test.
+func triggerProtocolError() int {
+	return int(C.clipboard_trigger_protocol_error())
 }


### PR DESCRIPTION
**Phase 1** of the Wayland design (#109 / `specs/wayland-support.md`): graceful-fail so the X11 backend can never abort the host.

## Problem
On a pure Wayland session the X selection is served against an invalid requestor window → `BadWindow` on `X_ChangeProperty`. Xlib's *default* error handler prints it and calls `exit(1)`, crashing the host program (#61).

## Fix
Install `XSetErrorHandler(ignoreXError)` in `initX11` (loaded via `dlsym` like the other symbols) so async protocol errors are swallowed instead of aborting the process. It's process-global — Xlib has no per-display protocol error handler — noted in a comment.

## Test (runs in CI)
`clipboard_errorhandler_linux_test.go` (tagged `linux && !android && cgo`) deliberately triggers a `BadWindow` and asserts the process survives. **Verified both directions in a Linux container:**
- with the handler → all tests pass (coverage 90.5%)
- without it → the test reproduces #61 exactly (`BadWindow ... Major opcode 18 (X_ChangeProperty) ... 0xffffffff`) and the binary crashes → `FAIL`

So it's a real fails-without/passes-with regression test, exercised by the existing ubuntu+xvfb job.

Refs #6, #61