### PR TITLE
wayland: pure-Go wire core + headless-sway test harness (phase 2)

### DIFF
--- a/.github/workflows/clipboard.yml
+++ b/.github/workflows/clipboard.yml
@@ -122,3 +122,29 @@ jobs:
           go version
           CGO_ENABLED=1 go build .
           CGO_ENABLED=1 go build ./cmd/gclip
+
+  # Exercise the native Wayland backend against a headless sway compositor.
+  # sway implements a data-control manager (zwlr_data_control_manager_v1),
+  # which the Wayland clipboard backend needs and which weston/cage do not.
+  wayland_test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        stable: 'false'
+        go-version: '1.24.x'
+    - name: Install sway and X11 dev headers
+      run: |
+        sudo apt update
+        sudo apt install -y sway libx11-dev
+    - name: Run Wayland tests under headless sway
+      run: |
+        export XDG_RUNTIME_DIR="${RUNNER_TEMP}/xdg"
+        mkdir -p "$XDG_RUNTIME_DIR" && chmod 700 "$XDG_RUNTIME_DIR"
+        export WLR_BACKENDS=headless WLR_LIBINPUT_NO_DEVICES=1 WLR_RENDERER=pixman
+        printf 'exec "go test -count=1 -covermode=atomic -run Wayland -v . > /tmp/res.txt 2>&1; echo EXIT=$? >> /tmp/res.txt; swaymsg exit"\n' > /tmp/sway.conf
+        timeout 180 sway -c /tmp/sway.conf || true
+        echo "----- go test output -----"
+        cat /tmp/res.txt
+        grep -q "^EXIT=0$" /tmp/res.txt

--- a/clipboard_wayland_linux.go
+++ b/clipboard_wayland_linux.go
@@ -1,0 +1,220 @@
+// Copyright 2026 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+//go:build linux && !android
+
+package clipboard
+
+// This file implements the wire-protocol core of a native Wayland clipboard
+// backend (see specs/wayland-support.md). It speaks the Wayland protocol
+// directly over the unix socket in pure Go — no Cgo, no libwayland — and is
+// the foundation for the data-control read/write/watch paths added in later
+// phases. Phase 2 covers connecting and discovering the advertised globals
+// (the seat and the data-control manager).
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+)
+
+// wlDisplayID is the well-known object id of the wl_display singleton; every
+// Wayland connection starts with it.
+const wlDisplayID = 1
+
+// wlGlobal is an entry advertised by wl_registry.global.
+type wlGlobal struct {
+	name    uint32
+	version uint32
+}
+
+// dataControlManagers lists the data-control manager interfaces we understand,
+// in order of preference. ext-data-control-v1 is the standardized successor to
+// the wlroots-specific zwlr_data_control_manager_v1; we accept either.
+var dataControlManagers = []string{
+	"ext_data_control_manager_v1",
+	"zwlr_data_control_manager_v1",
+}
+
+// waylandSocketPath returns the absolute path to the Wayland display socket,
+// or "" if the process is not in a Wayland session.
+func waylandSocketPath() string {
+	disp := os.Getenv("WAYLAND_DISPLAY")
+	if disp == "" {
+		return ""
+	}
+	if filepath.IsAbs(disp) {
+		return disp
+	}
+	dir := os.Getenv("XDG_RUNTIME_DIR")
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, disp)
+}
+
+// wlConn is a minimal Wayland protocol connection.
+type wlConn struct {
+	c      *net.UnixConn
+	nextID uint32
+}
+
+// wlConnect dials the Wayland display socket.
+func wlConnect() (*wlConn, error) {
+	p := waylandSocketPath()
+	if p == "" {
+		return nil, errUnavailable
+	}
+	c, err := net.DialUnix("unix", nil, &net.UnixAddr{Name: p, Net: "unix"})
+	if err != nil {
+		return nil, err
+	}
+	// Object ids 1.. are allocated by the client; 1 is wl_display.
+	return &wlConn{c: c, nextID: wlDisplayID + 1}, nil
+}
+
+func (w *wlConn) Close() error { return w.c.Close() }
+
+// newID allocates a fresh client-side object id.
+func (w *wlConn) newID() uint32 {
+	id := w.nextID
+	w.nextID++
+	return id
+}
+
+// request sends a Wayland request for objID with the given opcode and an
+// already-encoded argument payload.
+func (w *wlConn) request(objID uint32, opcode uint16, payload []byte) error {
+	size := 8 + len(payload)
+	if size > 0xffff {
+		return fmt.Errorf("wayland: message too large (%d bytes)", size)
+	}
+	msg := make([]byte, size)
+	binary.LittleEndian.PutUint32(msg[0:], objID)
+	binary.LittleEndian.PutUint32(msg[4:], uint32(size)<<16|uint32(opcode))
+	copy(msg[8:], payload)
+	_, err := w.c.Write(msg)
+	return err
+}
+
+// readEvent reads a single event: the sender object id, the opcode, and the
+// (header-stripped) body.
+func (w *wlConn) readEvent() (objID uint32, opcode uint16, body []byte, err error) {
+	var hdr [8]byte
+	if _, err = io.ReadFull(w.c, hdr[:]); err != nil {
+		return 0, 0, nil, err
+	}
+	objID = binary.LittleEndian.Uint32(hdr[0:])
+	word := binary.LittleEndian.Uint32(hdr[4:])
+	size := int(word >> 16)
+	opcode = uint16(word & 0xffff)
+	if size < 8 {
+		return 0, 0, nil, fmt.Errorf("wayland: invalid message size %d", size)
+	}
+	body = make([]byte, size-8)
+	if _, err = io.ReadFull(w.c, body); err != nil {
+		return 0, 0, nil, err
+	}
+	return objID, opcode, body, nil
+}
+
+// wlString decodes a length-prefixed, NUL-terminated, 32-bit-padded Wayland
+// string starting at off, returning the string and the offset just past it.
+func wlString(body []byte, off int) (string, int, error) {
+	if off+4 > len(body) {
+		return "", 0, io.ErrUnexpectedEOF
+	}
+	n := int(binary.LittleEndian.Uint32(body[off:]))
+	off += 4
+	padded := (n + 3) &^ 3
+	if n == 0 || off+padded > len(body) {
+		return "", 0, io.ErrUnexpectedEOF
+	}
+	s := string(body[off : off+n-1]) // strip trailing NUL
+	return s, off + padded, nil
+}
+
+// wlListGlobals connects, asks the registry for the advertised globals, and
+// returns them keyed by interface name. It uses a wl_display.sync barrier to
+// know when all globals have been delivered.
+func wlListGlobals() (map[string]wlGlobal, error) {
+	w, err := wlConnect()
+	if err != nil {
+		return nil, err
+	}
+	defer w.Close()
+
+	// wl_display.get_registry(new_id) — opcode 1.
+	registryID := w.newID()
+	arg := make([]byte, 4)
+	binary.LittleEndian.PutUint32(arg, registryID)
+	if err := w.request(wlDisplayID, 1, arg); err != nil {
+		return nil, err
+	}
+
+	// wl_display.sync(callback new_id) — opcode 0; the callback's done event
+	// marks the end of the initial registry burst.
+	callbackID := w.newID()
+	binary.LittleEndian.PutUint32(arg, callbackID)
+	if err := w.request(wlDisplayID, 0, arg); err != nil {
+		return nil, err
+	}
+
+	globals := make(map[string]wlGlobal)
+	for {
+		obj, opcode, body, err := w.readEvent()
+		if err != nil {
+			return nil, err
+		}
+		switch {
+		case obj == wlDisplayID && opcode == 0:
+			// wl_display.error(object_id, code, message)
+			return nil, wlDisplayError(body)
+		case obj == registryID && opcode == 0:
+			// wl_registry.global(name, interface, version)
+			if len(body) < 4 {
+				continue
+			}
+			name := binary.LittleEndian.Uint32(body[0:])
+			iface, off, err := wlString(body, 4)
+			if err != nil || off+4 > len(body) {
+				continue
+			}
+			version := binary.LittleEndian.Uint32(body[off:])
+			globals[iface] = wlGlobal{name: name, version: version}
+		case obj == callbackID && opcode == 0:
+			// wl_callback.done — registry enumeration complete.
+			return globals, nil
+		}
+	}
+}
+
+// wlDisplayError formats a wl_display.error event body for diagnostics.
+func wlDisplayError(body []byte) error {
+	if len(body) < 8 {
+		return fmt.Errorf("wayland: protocol error")
+	}
+	code := binary.LittleEndian.Uint32(body[4:])
+	msg, _, err := wlString(body, 8)
+	if err != nil {
+		return fmt.Errorf("wayland: protocol error (code %d)", code)
+	}
+	return fmt.Errorf("wayland: protocol error (code %d): %s", code, msg)
+}
+
+// dataControlManager returns the preferred available data-control manager
+// interface name from the advertised globals, or ok=false if none is present.
+func dataControlManager(globals map[string]wlGlobal) (string, wlGlobal, bool) {
+	for _, iface := range dataControlManagers {
+		if g, ok := globals[iface]; ok {
+			return iface, g, true
+		}
+	}
+	return "", wlGlobal{}, false
+}

--- a/clipboard_wayland_linux_test.go
+++ b/clipboard_wayland_linux_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+//go:build linux && !android
+
+package clipboard
+
+import (
+	"os"
+	"testing"
+)
+
+// TestWaylandDiscoverGlobals verifies the wire core can connect to a Wayland
+// compositor and discover the globals the data-control backend needs: a seat
+// and a data-control manager. It runs under the headless sway compositor in CI
+// (hack/test-wayland.sh / the wayland_test job) and skips when not in a Wayland
+// session.
+func TestWaylandDiscoverGlobals(t *testing.T) {
+	if os.Getenv("WAYLAND_DISPLAY") == "" {
+		t.Skip("not a Wayland session (WAYLAND_DISPLAY unset)")
+	}
+
+	globals, err := wlListGlobals()
+	if err != nil {
+		t.Fatalf("wlListGlobals: %v", err)
+	}
+	if len(globals) == 0 {
+		t.Fatal("no globals advertised by the compositor")
+	}
+
+	if _, ok := globals["wl_seat"]; !ok {
+		t.Errorf("compositor did not advertise wl_seat (got %d globals)", len(globals))
+	}
+
+	iface, g, ok := dataControlManager(globals)
+	if !ok {
+		t.Fatalf("compositor advertises no data-control manager; need one of %v", dataControlManagers)
+	}
+	t.Logf("data-control manager: %s (name=%d, version=%d); %d globals total",
+		iface, g.name, g.version, len(globals))
+}

--- a/hack/test-wayland.sh
+++ b/hack/test-wayland.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Copyright 2026 The golang.design Initiative Authors.
+# All rights reserved. Use of this source code is governed
+# by a MIT license that can be found in the LICENSE file.
+#
+# Run the Wayland tests inside a container under a headless sway compositor, so
+# the data-control backend can be exercised from any host (e.g. macOS) without
+# a real Wayland session. Mirrors the wayland_test CI job.
+#
+# sway is used because it implements a data-control manager
+# (zwlr_data_control_manager_v1); the reference compositor weston and the
+# minimal kiosk cage do not.
+#
+# Usage:
+#   hack/test-wayland.sh
+#   GO_VERSION=1.24 CONTAINER=podman hack/test-wayland.sh
+
+set -euo pipefail
+
+GO_VERSION="${GO_VERSION:-1.24}"
+
+runtime="${CONTAINER:-}"
+if [ -z "${runtime}" ]; then
+	if command -v docker >/dev/null 2>&1; then
+		runtime="docker"
+	elif command -v podman >/dev/null 2>&1; then
+		runtime="podman"
+	else
+		echo "error: neither docker nor podman found on PATH" >&2
+		exit 1
+	fi
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+echo "Running Wayland tests in ${runtime} (golang:${GO_VERSION}) under headless sway..."
+
+exec "${runtime}" run --rm -v "${repo_root}":/src -w /src "golang:${GO_VERSION}" bash -c '
+	set -e
+	apt-get update -qq >/dev/null
+	apt-get install -y -qq sway libx11-dev >/dev/null 2>&1
+	export XDG_RUNTIME_DIR=/tmp/xdg
+	mkdir -p "$XDG_RUNTIME_DIR" && chmod 700 "$XDG_RUNTIME_DIR"
+	export WLR_BACKENDS=headless WLR_LIBINPUT_NO_DEVICES=1 WLR_RENDERER=pixman
+	# Run the test suite as a sway client, then quit the compositor. sway sets
+	# WAYLAND_DISPLAY in the environment of processes it execs.
+	printf "exec \"go test -count=1 -covermode=atomic -run Wayland -v . > /tmp/res.txt 2>&1; echo EXIT=\$? >> /tmp/res.txt; swaymsg exit\"\n" > /tmp/sway.conf
+	timeout 180 sway -c /tmp/sway.conf >/tmp/sway.log 2>&1 || true
+	echo "----- go test output -----"
+	cat /tmp/res.txt 2>/dev/null || { echo "no test output; sway log:"; tail -20 /tmp/sway.log; exit 1; }
+	grep -q "^EXIT=0$" /tmp/res.txt
+'


### PR DESCRIPTION
**Phase 2** of the Wayland design (#109 / `specs/wayland-support.md`): the pure-Go wire-protocol foundation, fully exercised in CI.

## What
- `clipboard_wayland_linux.go` — a pure-Go Wayland client (no Cgo, no libwayland): unix-socket connect, message framing, `wl_display.get_registry` + `sync` roundtrip, registry global discovery, and `dataControlManager()` (prefers `ext_data_control_manager_v1`, falls back to `zwlr_data_control_manager_v1`).
- `clipboard_wayland_linux_test.go` — `TestWaylandDiscoverGlobals`: connects and asserts `wl_seat` + a data-control manager are advertised; skips off-Wayland.
- `hack/test-wayland.sh` + a new `wayland_test` CI job — run the tests under **headless sway** (the compositor that exposes a data-control manager; weston/cage don't).

## Verified
Ran in a headless-sway container:
```
TestWaylandDiscoverGlobals: data-control manager: zwlr_data_control_manager_v1 (version=2); 47 globals total
--- PASS
```

No behavior change: the wire core isn't wired into the package backend dispatch yet (later phase). Read/write/watch build on this next.

Phase 2 of #6.