### PR TITLE
wayland: dispatch the public API to the Wayland backend (closes #6)

### DIFF
--- a/.github/workflows/clipboard.yml
+++ b/.github/workflows/clipboard.yml
@@ -138,13 +138,17 @@ jobs:
       run: |
         sudo apt update
         sudo apt install -y sway libx11-dev wl-clipboard
-    - name: Run Wayland tests under headless sway
+    - name: Run the suite under headless sway
       run: |
         export XDG_RUNTIME_DIR="${RUNNER_TEMP}/xdg"
         mkdir -p "$XDG_RUNTIME_DIR" && chmod 700 "$XDG_RUNTIME_DIR"
         export WLR_BACKENDS=headless WLR_LIBINPUT_NO_DEVICES=1 WLR_RENDERER=pixman
-        printf 'exec "go test -count=1 -covermode=atomic -run Wayland -v . > /tmp/res.txt 2>&1; echo EXIT=$? >> /tmp/res.txt; swaymsg exit"\n' > /tmp/sway.conf
-        timeout 180 sway -c /tmp/sway.conf || true
+        # Run the whole suite as a sway client so the public API is exercised
+        # through the Wayland dispatch. xwayland is disabled (not needed; it
+        # would only log a missing-binary error). swaymsg's stderr is dropped
+        # because sway exits before acking the request.
+        printf 'xwayland disable\nexec "go test -count=1 -covermode=atomic -v . > /tmp/res.txt 2>&1; echo EXIT=$? >> /tmp/res.txt; swaymsg exit 2>/dev/null"\n' > /tmp/sway.conf
+        timeout 180 sway -c /tmp/sway.conf >/tmp/sway.log 2>&1 || true
         echo "----- go test output -----"
         cat /tmp/res.txt
-        grep -q "^EXIT=0$" /tmp/res.txt
+        grep -q "^EXIT=0$" /tmp/res.txt || { echo "----- sway log -----"; cat /tmp/sway.log; exit 1; }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ import "golang.design/x/clipboard"
 
 ## Features
 
-- Cross platform supports: **macOS, Linux (X11), Windows, BSD (X11), iOS, and Android**
+- Cross platform supports: **macOS, Linux (X11 and Wayland), Windows, BSD (X11), iOS, and Android**
 - Copy/paste UTF-8 text
 - Copy/paste PNG encoded images (Desktop-only)
 - Command `gclip` as a demo application
@@ -128,9 +128,14 @@ accessing system clipboards, but here are a few details you might need to know.
 ### Dependency
 
 - macOS: require Cgo, no dependency
- - Linux: require X11 dev package. For instance, install `libx11-dev` or `xorg-dev` or `libX11-devel` to access X window system.
-   Wayland sessions are currently unsupported; running under Wayland
-   typically requires an XWayland bridge and `DISPLAY` to be set.
+ - Linux: require X11 dev package for the X11 backend. For instance, install `libx11-dev` or `xorg-dev` or `libX11-devel` to access X window system.
+   Wayland is supported natively (no Cgo, no `libwayland`) on compositors
+   that expose a data-control manager (`ext-data-control-v1`, e.g. GNOME ≥ 49,
+   KWin, or `zwlr_data_control_manager_v1` on wlroots compositors such as Sway
+   and Hyprland). When `WAYLAND_DISPLAY` is set and such a manager is present,
+   the Wayland backend is used automatically; otherwise the package falls back
+   to X11 (via XWayland under Wayland). Older compositors without data-control
+   keep working through XWayland.
  - FreeBSD/OpenBSD/NetBSD: require Cgo and the X11 dev package (libX11),
    same as Linux. FreeBSD and OpenBSD are verified in CI; NetBSD shares
    the same X11 implementation on a best-effort basis and is untested.
@@ -153,6 +158,11 @@ accessing system clipboards, but here are a few details you might need to know.
   supported.
 - **Image format.** Image read/write assumes PNG-encoded data; other
   encodings are undefined behavior.
+- **Wayland.** The native Wayland backend uses the data-control protocol,
+  which works without keyboard focus. Compositors that do not implement
+  `ext-data-control-v1` or `zwlr_data_control_manager_v1` (e.g. GNOME
+  before 49) are not supported natively; the package falls back to X11 via
+  XWayland there. The `PRIMARY` selection is not exposed on Wayland either.
 
 ### Screenshot
 

--- a/clipboard_errorhandler_linux_test.go
+++ b/clipboard_errorhandler_linux_test.go
@@ -23,8 +23,14 @@ func TestX11ProtocolErrorDoesNotCrash(t *testing.T) {
 	if err := Init(); err != nil {
 		t.Skipf("clipboard unavailable: %v", err)
 	}
-	if got := triggerProtocolError(); got != 0 {
-		t.Fatalf("triggerProtocolError() = %d, want 0 (X display unavailable?)", got)
+	got := triggerProtocolError()
+	if got == -1 {
+		// No X display (e.g. a pure Wayland session, where Init uses the
+		// Wayland backend); there is no X connection to provoke an error on.
+		t.Skip("no X display available")
+	}
+	if got != 0 {
+		t.Fatalf("triggerProtocolError() = %d, want 0", got)
 	}
 	// Reaching here means the process survived the protocol error.
 }

--- a/clipboard_linux.go
+++ b/clipboard_linux.go
@@ -56,6 +56,14 @@ Then this package should be ready to use.
 `
 
 func initialize() error {
+	// Prefer the native Wayland backend when running under a Wayland session
+	// that exposes a data-control manager; this avoids the XWayland bridge and
+	// works without an X server. Fall back to X11 otherwise (including Wayland
+	// sessions whose compositor lacks data-control, via XWayland).
+	if wlAvailable() {
+		useWayland = true
+		return nil
+	}
 	ok := C.clipboard_test()
 	if ok != 0 {
 		return fmt.Errorf(helpmsg, errUnavailable)
@@ -64,6 +72,9 @@ func initialize() error {
 }
 
 func read(t Format) (buf []byte, err error) {
+	if useWayland {
+		return wlRead(t)
+	}
 	switch t {
 	case FmtText:
 		return readc("UTF8_STRING")
@@ -100,6 +111,9 @@ func readc(t string) ([]byte, error) {
 // write writes the given data to clipboard and
 // returns true if success or false if failed.
 func write(t Format, buf []byte) (<-chan struct{}, error) {
+	if useWayland {
+		return wlWrite(t, buf)
+	}
 	var s string
 	switch t {
 	case FmtText:
@@ -141,6 +155,9 @@ func write(t Format, buf []byte) (<-chan struct{}, error) {
 }
 
 func watch(ctx context.Context, t Format) <-chan []byte {
+	if useWayland {
+		return wlWatch(ctx, t)
+	}
 	recv := make(chan []byte, 1)
 	ti := time.NewTicker(time.Second)
 	last := Read(t)

--- a/clipboard_wayland_linux.go
+++ b/clipboard_wayland_linux.go
@@ -410,7 +410,14 @@ func wlReadSelection(mimes []string) ([]byte, error) {
 	if chosen == "" {
 		return nil, nil // none of the requested formats are available
 	}
-	return wlReceiveOffer(w, selection, chosen)
+	data, err := wlReceiveOffer(w, selection, chosen)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, nil // normalize empty to nil, matching the X11 backend
+	}
+	return data, nil
 }
 
 // wlReceiveOffer requests data for mime from the given offer and reads it from
@@ -586,8 +593,10 @@ func wlWrite(t Format, data []byte) (<-chan struct{}, error) {
 			wlServeSend(w, body, data)
 		}
 		if obj == sourceID && op == srcEvtCancelled {
+			// Replaced immediately; deliver the overwrite signal and close.
 			w.Close()
-			done := make(chan struct{})
+			done := make(chan struct{}, 1)
+			done <- struct{}{}
 			close(done)
 			return done, nil
 		}
@@ -596,9 +605,14 @@ func wlWrite(t Format, data []byte) (<-chan struct{}, error) {
 		}
 	}
 
-	done := make(chan struct{})
+	// The channel receives one signal then closes when ownership is lost,
+	// matching the package Write contract.
+	done := make(chan struct{}, 1)
 	go func() {
-		defer close(done)
+		defer func() {
+			done <- struct{}{}
+			close(done)
+		}()
 		defer w.Close()
 		for {
 			obj, op, body, err := w.readEvent()
@@ -652,22 +666,82 @@ func wlWatch(ctx context.Context, t Format) <-chan []byte {
 		return recv
 	}
 
+	w, _, deviceID, err := wlConnectDevice()
+	if err != nil {
+		close(recv)
+		return recv
+	}
+
+	offers := make(map[uint32][]string)
+	// fetch resolves the data for a selection event: it forgets stale offers,
+	// then reads the current selection's bytes (nil if empty or unsupported).
+	fetch := func(sel uint32) []byte {
+		for id := range offers {
+			if id != sel {
+				w.request(id, offerOpcodeDestroy, nil)
+				delete(offers, id)
+			}
+		}
+		if sel == 0 {
+			return nil
+		}
+		chosen := pickMIME(mimes, offers[sel])
+		if chosen == "" {
+			return nil
+		}
+		d, err := wlReceiveOffer(w, sel, chosen)
+		if err != nil || len(d) == 0 {
+			return nil
+		}
+		return d
+	}
+
+	// Capture the current selection synchronously as the baseline (mirrors the
+	// X11 watch reading the current value before returning), so a write that
+	// happens right after Watch returns is reported rather than swallowed.
+	var last []byte
+	sync1, err := w.sync()
+	if err != nil {
+		w.Close()
+		close(recv)
+		return recv
+	}
+baseline:
+	for {
+		obj, op, body, err := w.readEvent()
+		if err != nil {
+			w.Close()
+			close(recv)
+			return recv
+		}
+		switch {
+		case obj == wlDisplayID && op == 0:
+			w.Close()
+			close(recv)
+			return recv
+		case obj == sync1 && op == 0:
+			break baseline
+		case obj == deviceID && op == devEvtDataOffer && len(body) >= 4:
+			offers[binary.LittleEndian.Uint32(body[0:])] = nil
+		case obj == deviceID && op == devEvtSelection && len(body) >= 4:
+			last = fetch(binary.LittleEndian.Uint32(body[0:]))
+		case op == offerEvtOffer:
+			if _, isOffer := offers[obj]; isOffer {
+				if mime, _, err := wlString(body, 0); err == nil {
+					offers[obj] = append(offers[obj], mime)
+				}
+			}
+		}
+	}
+
 	go func() {
 		defer close(recv)
-		w, _, deviceID, err := wlConnectDevice()
-		if err != nil {
-			return
-		}
 		defer w.Close()
 		// Closing the connection when ctx is done unblocks readEvent.
 		go func() {
 			<-ctx.Done()
 			w.Close()
 		}()
-
-		offers := make(map[uint32][]string)
-		var last []byte
-		baselineSet := false
 		for {
 			obj, op, body, err := w.readEvent()
 			if err != nil {
@@ -678,36 +752,8 @@ func wlWatch(ctx context.Context, t Format) <-chan []byte {
 				return
 			case obj == deviceID && op == devEvtDataOffer && len(body) >= 4:
 				offers[binary.LittleEndian.Uint32(body[0:])] = nil
-			case op == offerEvtOffer:
-				if _, isOffer := offers[obj]; isOffer {
-					if mime, _, err := wlString(body, 0); err == nil {
-						offers[obj] = append(offers[obj], mime)
-					}
-				}
 			case obj == deviceID && op == devEvtSelection && len(body) >= 4:
-				sel := binary.LittleEndian.Uint32(body[0:])
-				// Destroy and forget every offer except the current one.
-				for id := range offers {
-					if id != sel {
-						w.request(id, offerOpcodeDestroy, nil)
-						delete(offers, id)
-					}
-				}
-				var data []byte
-				if sel != 0 {
-					if chosen := pickMIME(mimes, offers[sel]); chosen != "" {
-						if d, err := wlReceiveOffer(w, sel, chosen); err == nil {
-							data = d
-						}
-					}
-				}
-				// The first selection event reflects the state at connect time;
-				// treat it as the baseline and only report later changes.
-				if !baselineSet {
-					baselineSet = true
-					last = data
-					continue
-				}
+				data := fetch(binary.LittleEndian.Uint32(body[0:]))
 				if bytes.Equal(data, last) {
 					continue
 				}
@@ -720,8 +766,33 @@ func wlWatch(ctx context.Context, t Format) <-chan []byte {
 				case <-ctx.Done():
 					return
 				}
+			case op == offerEvtOffer:
+				if _, isOffer := offers[obj]; isOffer {
+					if mime, _, err := wlString(body, 0); err == nil {
+						offers[obj] = append(offers[obj], mime)
+					}
+				}
 			}
 		}
 	}()
 	return recv
+}
+
+// useWayland is set by initialize() when the native Wayland backend is in use,
+// so read/write/watch dispatch to it instead of the X11 path.
+var useWayland bool
+
+// wlAvailable reports whether the process is in a Wayland session whose
+// compositor exposes a data-control manager (ext or wlroots). It performs a
+// real probe by connecting and listing globals.
+func wlAvailable() bool {
+	if os.Getenv("WAYLAND_DISPLAY") == "" {
+		return false
+	}
+	globals, err := wlListGlobals()
+	if err != nil {
+		return false
+	}
+	_, _, ok := dataControlManager(globals)
+	return ok
 }

--- a/hack/test-wayland.sh
+++ b/hack/test-wayland.sh
@@ -42,9 +42,12 @@ exec "${runtime}" run --rm -v "${repo_root}":/src -w /src "golang:${GO_VERSION}"
 	export XDG_RUNTIME_DIR=/tmp/xdg
 	mkdir -p "$XDG_RUNTIME_DIR" && chmod 700 "$XDG_RUNTIME_DIR"
 	export WLR_BACKENDS=headless WLR_LIBINPUT_NO_DEVICES=1 WLR_RENDERER=pixman
-	# Run the test suite as a sway client, then quit the compositor. sway sets
-	# WAYLAND_DISPLAY in the environment of processes it execs.
-	printf "exec \"go test -count=1 -covermode=atomic -run Wayland -v . > /tmp/res.txt 2>&1; echo EXIT=\$? >> /tmp/res.txt; swaymsg exit\"\n" > /tmp/sway.conf
+	# Run the whole suite as a sway client, so the public API (Init/Read/Write/
+	# Watch) is exercised through the Wayland dispatch, then quit the compositor.
+	# sway sets WAYLAND_DISPLAY in the environment of processes it execs.
+	# xwayland is disabled: we do not need it and it just logs a missing-binary
+	# error in CI.
+	printf "xwayland disable\nexec \"go test -count=1 -covermode=atomic -v . > /tmp/res.txt 2>&1; echo EXIT=\$? >> /tmp/res.txt; swaymsg exit 2>/dev/null\"\n" > /tmp/sway.conf
 	timeout 180 sway -c /tmp/sway.conf >/tmp/sway.log 2>&1 || true
 	echo "----- go test output -----"
 	cat /tmp/res.txt 2>/dev/null || { echo "no test output; sway log:"; tail -20 /tmp/sway.log; exit 1; }


### PR DESCRIPTION
**Phase 7 (final)** of the Wayland design (#109): wire the native Wayland backend into the public API, completing #6.

## What
- `initialize()` probes for a Wayland data-control session (`WAYLAND_DISPLAY` + an `ext`/`zwlr` data-control manager). If present, `Read`/`Write`/`Watch` use the **pure-Go Wayland backend** (no X server needed); otherwise they fall back to X11 (via XWayland under Wayland). Older compositors without data-control keep working through XWayland.
- Contract alignment found by running the existing suite through the Wayland path:
  - empty reads return `nil` (like X11);
  - the `Write` channel delivers one overwrite signal then closes;
  - `Watch` captures the current selection **synchronously** as a baseline before returning (fixes a race where a write right after `Watch` was swallowed — it had hung `ExampleWatch`).
- `wayland_test` CI job + `hack/test-wayland.sh` now run the **whole suite** under headless sway, so the public API (`TestClipboard`, `TestClipboardMultipleWrites`, `TestClipboardWatch`, `ExampleWatch`, …) is exercised through the Wayland dispatch. XWayland disabled for clean logs.
- README documents Wayland support.

## Verified under headless sway (full suite via the Wayland dispatch)
```
TestClipboard/image, /text     PASS
TestClipboardMultipleWrites    PASS
TestClipboardWriteEmpty        PASS
TestClipboardWatch             PASS
ExampleWatch                   PASS   (was hanging ~172s before the baseline fix)
TestWayland{DiscoverGlobals,ReadText,WriteText,Watch}  PASS
coverage: 67.0%
```

Native Wayland support is now complete (phases 1–7). Closes #6.