### PR TITLE
specs: correct mobile Cgo conclusion — iOS is not feasible either

### DIFF
--- a/specs/mobile-remove-cgo.md
+++ b/specs/mobile-remove-cgo.md
@@ -1,11 +1,19 @@
-# Design: drop the Cgo / C-toolchain dependency on mobile (iOS, Android)
+# Design: Cgo on mobile (iOS, Android) — investigation and conclusion
 
 | | |
 |---|---|
-| **Status** | Proposed |
-| **Issue** | _none open_ — closes the mobile gap left by #69/#25; see [#8](https://github.com/golang-design/clipboard/issues/8) (Android support), [#70](https://github.com/golang-design/clipboard/issues/70) (Android fails to build) |
-| **Builds on** | [#117](https://github.com/golang-design/clipboard/pull/117) / [`specs/darwin-remove-cgo.md`](./darwin-remove-cgo.md) — the purego/objc pasteboard binding this mirrors |
-| **Related** | [#25](https://github.com/golang-design/clipboard/issues/25) (Linux/X11), [#69](https://github.com/golang-design/clipboard/issues/69) (darwin) — the desktop Cgo-removal track this completes |
+| **Status** | Accepted — **negative result: mobile keeps Cgo** (iOS and Android) |
+| **Issue** | [#125](https://github.com/golang-design/clipboard/issues/125) (iOS — closed not-feasible), [#126](https://github.com/golang-design/clipboard/issues/126) (Android — tracked blocker); see also [#8](https://github.com/golang-design/clipboard/issues/8), [#70](https://github.com/golang-design/clipboard/issues/70) |
+| **Builds on** | [#117](https://github.com/golang-design/clipboard/pull/117) / [`specs/darwin-remove-cgo.md`](./darwin-remove-cgo.md) — the purego/objc binding iOS was expected to mirror |
+| **Related** | [#25](https://github.com/golang-design/clipboard/issues/25) (Linux/X11), [#69](https://github.com/golang-design/clipboard/issues/69) (darwin) — the desktop Cgo-removal track that *did* succeed |
+
+> **Correction (this revision).** The first version of this spec concluded that
+> **iOS was actionable** (port `UIPasteboard` to purego/objc, mirroring darwin
+> #117) while only Android stayed Cgo. An implementation attempt proved that
+> **wrong**: iOS cannot drop the C-toolchain dependency either. §4 records the two
+> independent blockers and §6 records why the original feasibility check was a
+> false positive. The corrected conclusion: **neither mobile platform can drop
+> Cgo**, for different reasons. No source change lands from this spec.
 
 ## 1. Current state
 
@@ -16,214 +24,166 @@ The two mobile backends both bind native clipboard APIs through Cgo:
   UIKit -framework MobileCoreServices`) and declares two C functions;
   `clipboard_ios.m` implements them against `UIPasteboard` (`generalPasteboard`,
   `string`, `setString:`). Only `FmtText` is supported; `FmtImage` returns
-  `errUnsupported`. **It imports no `golang.org/x/mobile` package** — iOS
+  `errUnsupported`. It imports no `golang.org/x/mobile` package — iOS
   `UIPasteboard` is process-global and needs no Activity/Context handle.
 - **Android** — `clipboard_android.go` (`//go:build android`) declares two C
   functions; `clipboard_android.c` implements them with **JNI** against the
   Android `ClipboardManager`. The JNI calls need a live `JNIEnv` + app `Context`,
   obtained via `golang.org/x/mobile/app.RunOnJVM(func(vm, env, ctx uintptr) ...)`.
 
-Consequences of the Cgo dependency (same shape as #69/#25 on the desktop):
+After darwin (#117), Linux (#120), and BSD (#121) went Cgo-free, these two were
+the remaining backends dragging in a C compiler. This spec set out to remove
+them and concluded it cannot be done.
 
-- Building either backend **requires a C toolchain** and `CGO_ENABLED=1`.
-- Under `CGO_ENABLED=0` a file with `import "C"` is dropped from the build, and
-  `clipboard_nocgo.go` excludes `darwin` (so it never covers iOS). The result is
-  the same silent-degradation bug #69 fixed on darwin — verified empirically:
+## 2. The bar a platform must clear
 
-  ```
-  $ GOOS=ios     GOARCH=arm64 CGO_ENABLED=0 go build .
-  ./clipboard.go:144:15: undefined: initialize   # …read/write/watch too
-  $ GOOS=android GOARCH=arm64 CGO_ENABLED=0 go build .
-  ./clipboard.go:144:15: undefined: initialize   # same
-  ```
+Dropping the C-toolchain dependency requires **two** things, not one:
 
-  Neither a working backend *nor* the graceful `ErrCgoDisabled` stubs are linked.
+1. **The library compiles Cgo-free** — every package it imports builds under
+   `CGO_ENABLED=0` for that `GOOS`.
+2. **An artifact can be produced Cgo-free** — the Go toolchain can link a binary
+   (or the platform's app build can package one) for that `GOOS` without a C
+   linker.
 
-Now that darwin (#117), Linux (#120), and BSD (#121) are Cgo-free, the two mobile
-backends are the last ones that drag in a C compiler.
+Desktop platforms clear both: darwin/linux/windows/bsd compile pure-Go backends
+*and* internal-link `CGO_ENABLED=0` binaries. **Both mobile platforms fail —
+iOS fails both bars, Android fails bar 1.** The details:
 
-## 2. The decisive question, applied per platform
-
-The single test that decides feasibility: **can the platform's clipboard backend
-function without importing a package that itself requires Cgo?**
-
-| | library compiles cgo-free? | reachable API | verdict |
+| | bar 1: compiles cgo-free? | bar 2: links/packages cgo-free? | verdict |
 |---|---|---|---|
-| **iOS** | ✅ stdlib builds (`GOOS=ios CGO_ENABLED=0 go build std` ✓); backend imports no cgo package | `UIPasteboard` via `purego/objc` (process-global, no Context) | **actionable** |
-| **Android** | ❌ backend needs `x/mobile/app.RunOnJVM` → `mobileinit.RunOnJVM` → `C.lockJNI` (cgo) | `ClipboardManager` via JNI, but only reachable through the cgo JVM bridge | **non-goal** |
+| **iOS** | ❌ purego forbids it (§4.1) | ❌ Go's iOS port forces external/C linking (§4.2) | **not feasible** |
+| **Android** | ❌ needs `x/mobile/app` → `C.lockJNI` (§5) | ❌ gomobile builds `-buildmode=c-shared` via the NDK (§5) | **not feasible** |
 
-iOS passes; Android fails on a hard dependency. The rest of the spec follows from
-this split. There is no Android escape hatch within the gomobile model (§7).
+## 3. Goal & conclusion
 
-## 3. Goal & non-goals
+**Original goal:** build the library for `GOOS=ios` (and, aspirationally, the
+Android backend) with `CGO_ENABLED=0` and no C toolchain.
 
-**Goal:** the `golang.design/x/clipboard` **library** builds for `GOOS=ios` with
-**`CGO_ENABLED=0`** and **no C toolchain**, with behavior identical to today
-(text read/write/watch; image remains unsupported on iOS). This also fixes the
-silent-degradation bug (§1) for iOS.
+**Conclusion: not achievable on either mobile platform.** Both stay Cgo. This is
+now a documented non-goal with the supporting analysis below, so the question is
+not re-investigated from scratch. `cmd/gclip-gui` (Fyne/OpenGL, Cgo regardless)
+was never in scope and is untouched.
 
-**Non-goals — and be precise about the iOS one, because it is easy to overclaim:**
+## 4. iOS — why it stays Cgo
 
-- **A gomobile *app* does not become Cgo-free.** This spec removes Cgo from the
-  *clipboard library*. `golang.org/x/mobile/app`'s `darwin_ios.go` is itself
-  `import "C"`, so any gomobile iOS app still links Cgo via x/mobile's own
-  scaffolding regardless of this package. The win is at the **library** level:
-  the package cross-compiles to iOS from a toolchain-less environment, stops
-  degrading to undefined symbols / no-op stubs, and stops *forcing* Cgo on
-  consumers that bind iOS clipboard access without the full gomobile app harness.
-  The three-way framing:
+iOS fails **both** bars in §2, each independently fatal.
 
-  | platform | library forces Cgo? | typical consumer links Cgo? |
-  |---|---|---|
-  | darwin (#117) | no | no |
-  | **iOS (this spec)** | **no** | yes, from x/mobile app scaffolding (not from us) |
-  | **Android (this spec)** | **yes** (unavoidable) | yes |
+### 4.1 purego requires Cgo on iOS (fails bar 1)
 
-- **Android stays Cgo.** See §7 — it is documented as a non-goal with its full
-  dependency analysis, not silently skipped.
-- No public API change; no new clipboard formats; `cmd/gclip-gui` (Fyne/OpenGL,
-  Cgo regardless) is untouched.
-
-## 4. iOS — the binding (mirror darwin)
-
-A near-copy of the darwin purego/objc backend (`clipboard_darwin.go`), retargeted
-from `NSPasteboard` to `UIPasteboard`. Because `UIPasteboard` is process-global,
-this is *simpler* than darwin: text-only, no image, no TIFF fallback.
+The intended binding reused `github.com/ebitengine/purego` + `purego/objc`, as
+darwin does. But purego deliberately refuses to build for iOS under
+`CGO_ENABLED=0`. `purego/is_ios.go` (effective constraint `ios && !cgo`) is a
+compile-time tripwire:
 
 ```go
-//go:build ios
-
-class_UIPasteboard := objc.GetClass("UIPasteboard")
-class_NSString     := objc.GetClass("NSString")
-sel_generalPasteboard := objc.RegisterName("generalPasteboard")
-sel_string            := objc.RegisterName("string")
-sel_setString         := objc.RegisterName("setString:")
-// + NSString <-> bytes via initWithBytes:length:encoding: / dataUsingEncoding:
+//go:build !cgo
+package purego
+// if you are getting this error it means that you have
+// CGO_ENABLED=0 while trying to build for ios.
+// purego does not support this mode yet.
+// the fix is to set CGO_ENABLED=1 which will require a C compiler.
+var _ = _PUREGO_REQUIRES_CGO_ON_IOS
 ```
 
-- **`read(FmtText)`** → `[[UIPasteboard generalPasteboard] string]` → an
-  `NSString`; convert to bytes with `dataUsingEncoding:` (NSUTF8 = 4) and copy via
-  the shared `nsdataBytes` helper. `read(FmtImage)` → `errUnsupported` (unchanged).
-- **`write(FmtText)`** → build an `NSString` with
-  `+[NSString stringWithUTF8String:]` (or `-initWithBytes:length:encoding:` to be
-  NUL-safe) and `[pasteboard setString:]`. `write(FmtImage)` → `errUnsupported`.
-- **`watch`** → keep the existing poll-`Read` diff loop (1 s cadence), unchanged.
-  `UIPasteboard.changeCount` exists but is not needed to preserve current
-  behavior; not adopting it keeps the objc surface minimal.
+So the moment the iOS backend imports `purego/objc`, the library no longer
+compiles Cgo-free for `GOOS=ios`:
 
-**Class reachability:** in a UIKit process `UIPasteboard`/`NSString` are already
-loaded, so `objc.GetClass` returns them without a `Dlopen`. No exported-symbol
-constants are needed (encodings are compile-time enum values), so unlike darwin
-there is **no `purego.Dlsym`**. As with darwin there are **no struct return
-values**, keeping the binding inside purego's proven `objc_msgSend` envelope on
-`arm64`.
+```
+$ GOOS=ios GOARCH=arm64 CGO_ENABLED=0 go build .
+# github.com/ebitengine/purego
+.../purego@v0.10.1/is_ios.go:13:9: undefined: _PUREGO_REQUIRES_CGO_ON_IOS
+```
 
-### Correctness (carry over the darwin lessons)
+Still true on the latest release (v0.10.1; only `v0.11.0-alpha*` exist beyond).
+This is the same toolchain that made darwin succeed — it just draws an explicit
+line at iOS. Hand-rolling an `objc_msgSend` bridge to avoid purego is the work
+purego itself declined to do on iOS; out of scope and self-defeating.
 
-- **Autorelease pools.** `-string` and the `NSString`/`NSData` accessors return
-  *autoreleased* objects; these goroutines run on arbitrary OS threads with no
-  pool, so without draining they leak — including in the per-second `watch` loop.
-  Wrap each operation in an autorelease pool (`defer newAutoreleasePool()()`).
-- **Keep Go buffers alive.** `runtime.KeepAlive` around any `Send` that passes a
-  Go slice's backing pointer (write path), exactly as darwin does.
-- **Fixes a latent use-after-free.** Today's `clipboard_ios.m`
-  `return (char *)[str UTF8String];` hands back a pointer into autoreleased
-  storage with no copy — a use-after-free the moment the pool drains. The purego
-  port copies bytes out via `nsdataBytes`, eliminating it. A read test asserting
-  round-tripped bytes is the regression guard.
+### 4.2 Go's iOS port forces external (C) linking (fails bar 2)
 
-### Shared darwin/iOS code
+Even setting purego aside, the Go toolchain cannot link an iOS artifact without
+Cgo. A bare empty program proves it, independent of this package:
 
-`newAutoreleasePool`, `nsdataBytes`, and the `must`/`must2` helpers in
-`clipboard_darwin.go` are platform-neutral within Apple — only the pasteboard
-class and selectors differ. The build tag `darwin` **includes** `ios`, so factor
-them into a `clipboard_apple.go` (`//go:build darwin`) shared file, leaving
-`clipboard_darwin.go` (`darwin && !ios`) and `clipboard_ios.go` (`ios`) to hold
-only their pasteboard-specific bindings. Decide at impl time; do not duplicate.
+```
+$ printf 'package main\nfunc main(){}\n' > m.go
+$ GOOS=ios GOARCH=arm64 CGO_ENABLED=0 go build m.go
+ios/arm64 requires external (cgo) linking, but cgo is not enabled
+```
 
-## 5. Files touched (iOS)
+For contrast, **darwin** (non-iOS) internal-links the same program with
+`CGO_ENABLED=0` — which is precisely why #117 worked and this does not. Any iOS
+binary, and any gomobile iOS app, therefore needs a C toolchain to link,
+regardless of how the clipboard is bound.
+
+**Net for iOS:** the library can be neither compiled nor linked for iOS without
+Cgo. The `clipboard_ios.go` / `clipboard_ios.m` Cgo backend stays as-is.
+
+## 5. Android — why it stays Cgo
+
+Android fails bar 1 on a hard dependency chain, and bar 2 on the build model:
+
+1. **The JNI bridge is Cgo by construction (bar 1).** `clipboard_android.c` makes
+   JNI calls and needs a live `JNIEnv` + app `Context`, obtained from
+   `golang.org/x/mobile/app.RunOnJVM` → `internal/mobileinit.RunOnJVM`, which is
+   implemented with **`C.lockJNI` / `C.unlockJNI` / `C.checkException`**
+   (`ctx_android.go`, `import "C"`). The backend pulls Cgo transitively before
+   its own C file. Empirically, `GOOS=android CGO_ENABLED=0 go build .` fails on
+   the `x/mobile/app` import.
+2. **The gomobile app model is Cgo by construction (bar 2).** Android gomobile
+   apps build `-buildmode=c-shared` and load via a `NativeActivity` through the
+   NDK; `CGO_ENABLED=0` is not a supported Android flow. The NDK is required to
+   package the app regardless of clipboard binding.
+
+**Considered and rejected — purego-over-JNI.** purego supports Android `dlopen`
+(`dlfcn_android.go`), so one could call the `JNIEnv` function-table pointers from
+Go and delete `clipboard_android.c`. Rejected: it removes neither the
+`x/mobile/app` Cgo dependency nor the NDK requirement — churn and added `unsafe`
+risk with zero movement toward the goal. Revisit only if the JVM/`Context`
+lifecycle becomes obtainable without a Cgo `x/mobile` dependency.
+
+## 6. Why the first conclusion was wrong (the false-positive check)
+
+The original spec's iOS feasibility rested on this passing:
+
+```
+$ GOOS=ios GOARCH=arm64 CGO_ENABLED=0 go build std   # ✅ — but proves nothing
+```
+
+`go build std` **compiles individual standard-library packages but never links a
+binary and never imports purego**, so it sidesteps *both* §4 blockers. It was a
+false green. The check that would have caught it is building the actual
+library-with-purego and linking a target:
+
+```
+$ GOOS=ios GOARCH=arm64 CGO_ENABLED=0 go build .            # purego tripwire (§4.1)
+$ GOOS=ios GOARCH=arm64 CGO_ENABLED=0 go build ./cmd/gclip  # external-linking (§4.2)
+```
+
+**Lesson for future platform specs:** a `go build std` (or any compile-only)
+check is not evidence a platform can drop Cgo. Verify by (a) building the real
+package with its FFI dependency under `CGO_ENABLED=0`, and (b) linking an actual
+binary for that `GOOS`. Both bars in §2 must be checked explicitly.
+
+## 7. Net result & files touched
+
+**No source change.** Both mobile backends remain Cgo:
 
 | File | Change |
 |---|---|
-| `clipboard_ios.go` | Replace Cgo preamble + bodies with a purego/objc `UIPasteboard` binding; keep `//go:build ios`. Builds under `CGO_ENABLED=0`. |
-| `clipboard_ios.m` | **Delete.** |
-| `clipboard_apple.go` *(new, optional)* | `//go:build darwin` shared `newAutoreleasePool`/`nsdataBytes`/`must` lifted from `clipboard_darwin.go`. |
-| `clipboard_nocgo.go` | Add `&& !ios` (and keep `!android`) so iOS no longer falls through to stubs. Android **still** falls through — see §7. |
-| `clipboard_test.go` | Any `TestClipboardNoCgo`/`TestClipboardInit` assumptions about iOS returning `ErrCgoDisabled` must change (iOS no longer does). |
-| `README.md` | `iOS/Android: collaborate with gomobile` → split: iOS gains a "no Cgo (library)" note like darwin; Android keeps the gomobile/Cgo note with the §7 rationale. |
-| `go.mod` | No change — `github.com/ebitengine/purego` is already a dependency (darwin). |
+| `clipboard_ios.go`, `clipboard_ios.m` | **Unchanged** — Cgo `UIPasteboard` backend stays (§4). |
+| `clipboard_android.go`, `clipboard_android.c` | **Unchanged** — Cgo JNI backend stays (§5). |
+| `clipboard_nocgo.go` | **Unchanged** — keeps its `!android` exclusion; `darwin` already covers `ios`, so iOS resolves to the Cgo backend, not the stubs. |
+| `README.md` | The existing "iOS/Android: collaborate with gomobile" line is already accurate; no edit required. |
 
-## 6. Testing & CI (iOS)
+`clipboard_test.go`'s `degradesWithoutCgo` already classifies the mobile
+platforms correctly (they degrade without Cgo), consistent with this conclusion.
 
-iOS cannot run `go test` on GitHub-hosted runners (no device/simulator). Mirror
-the existing build-only jobs (`freebsd_build`, `openbsd_build`, `windows_386_build`):
+## 8. Risk & effort
 
-- Add a **build-only** job: `GOOS=ios GOARCH=arm64 CGO_ENABLED=0 go build .`
-  (the `std` half of this already passes; see §1/§2). This is the proof the
-  toolchain is gone and the silent-degradation bug is fixed.
-- Add a pure-Go unit test for the byte round-trip / use-after-free fix where it
-  can run without a device — i.e. a small helper test, since the live pasteboard
-  path itself is device-only.
-- **Runtime verification is device-only**, via the `gclip-gui` demo on a real
-  iOS device. Flag at impl time: confirm `UIPasteboard`/`NSString` are reachable
-  through purego/objc on-device (cannot be exercised in CI).
-- Land the binding and its test/CI adjustments in the **same PR** — no untested
-  intermediate state.
-
-## 7. Android — why it stays Cgo (non-goal, with the analysis)
-
-Android cannot reach the goal, and the reason is a hard dependency chain, not an
-implementation gap:
-
-1. **The package's JNI bridge is Cgo by construction.** `clipboard_android.c`
-   makes JNI calls (`GetMethodID`, `CallObjectMethod`, …), and it needs a live
-   `JNIEnv` + app `Context`. Those come from
-   `golang.org/x/mobile/app.RunOnJVM`, which delegates to
-   `internal/mobileinit.RunOnJVM` — implemented with **`C.lockJNI` / `C.unlockJNI`
-   / `C.checkException`** (`ctx_android.go`, `import "C"`). So the backend pulls
-   Cgo transitively even before its own C file.
-2. **The gomobile app model is Cgo by construction.** Android gomobile apps are
-   built `-buildmode=c-shared` and loaded by a `NativeActivity` through the NDK —
-   `CGO_ENABLED=0` is not a supported gomobile Android flow at all. The C
-   toolchain (NDK) is required to *package* the app regardless of how the
-   clipboard is bound. Empirically, `GOOS=android CGO_ENABLED=0 go build .`
-   already fails on the x/mobile/app import.
-
-**Considered and rejected — purego-over-JNI.** purego supports Android `dlopen`
-(`dlfcn_android.go`), so in principle one could replace `clipboard_android.c` by
-calling the `JNIEnv` function-table pointers directly from Go. Rejected: it would
-**not** remove the C-toolchain requirement (x/mobile/app stays Cgo; the NDK
-c-shared build stays). It is churn and added `unsafe` risk with **zero** movement
-toward the goal. Revisit only if/when the JVM/Context lifecycle can be obtained
-without a cgo x/mobile dependency — out of scope here. (Tracks the upstream
-constraint noted around #70.)
-
-**Net for Android:** no source change. It continues to require Cgo + the NDK, and
-`clipboard_nocgo.go` keeps its `!android` exclusion so a `CGO_ENABLED=0` build of
-the library on a non-mobile host still resolves to the graceful stubs.
-
-## 8. Implementation phases
-
-1. **iOS binding** — port `clipboard_ios.go` to purego/objc on `UIPasteboard`
-   (text read/write/watch); delete `clipboard_ios.m`; factor the shared Apple
-   helpers (§4); flip the `nocgo` tag (`!ios`); fix the affected test
-   assumptions. Verify `GOOS=ios CGO_ENABLED=0 go build .` is green.
-2. **CI** — add the `ios_build` build-only job (§6).
-3. **Docs** — README iOS line (no-Cgo at library level) + Android rationale (§7);
-   note iOS is now Cgo-free for the library in the package doc.
-
-## 9. Risk & effort
-
-- **Effort:** small. iOS is a strict subset of the already-shipped darwin binding
-  (text-only, no image, no TIFF, no `Dlsym`); much of the code is shared verbatim.
-- **Risk:**
-  - *On-device reachability* of `UIPasteboard` via purego/objc — cannot be
-    CI-verified; mitigated by the `gclip-gui` device check (§6).
-  - *Autorelease leaks* in long-running `watch` — mitigated by reusing darwin's
-    `newAutoreleasePool` (§4), and invisible to CI, hence flagged.
-  - *Overclaiming the benefit* — mitigated by the explicit library-vs-app framing
-    (§3); the spec deliberately does not promise a Cgo-free gomobile app.
-- **Upside:** iOS joins darwin/Linux/Windows/BSD as a Cgo-free library backend;
-  cross-compiling the library to iOS without a toolchain becomes possible; the
-  iOS silent-degradation + use-after-free bugs are fixed. Android's status is now
-  documented rather than ambiguous.
+- **Effort:** none (no code). The value delivered is the *negative result* —
+  iOS and Android are now known-and-documented non-goals, with reproducible
+  evidence, so the investigation is not repeated.
+- **Residual upside path:** revisit iOS if purego lifts its `ios && !cgo`
+  restriction *and* Go's iOS port stops mandating external linking (neither is on
+  the horizon); revisit Android if the JVM/`Context` lifecycle becomes reachable
+  without a Cgo `x/mobile` dependency. Until then, mobile stays Cgo.


### PR DESCRIPTION
Corrects the merged mobile Cgo spec (#123). Implementing #125 disproved its iOS conclusion.

## What changed
The spec said **iOS was actionable** (purego/objc on `UIPasteboard`, mirroring darwin #117) and only Android stayed Cgo. That's wrong. **iOS cannot drop Cgo either**, for two independent reasons — both verified by attempting the implementation:

1. **purego forbids cgo-free iOS.** `purego/is_ios.go` (`ios && !cgo`) is a deliberate compile-time tripwire (`_PUREGO_REQUIRES_CGO_ON_IOS`). Once the iOS backend imports `purego/objc`, `GOOS=ios CGO_ENABLED=0 go build .` fails to compile. Still true on latest (v0.10.1).
2. **Go's iOS port forces external (C) linking.** Independent of our code — an empty `func main(){}` fails `GOOS=ios CGO_ENABLED=0 go build` with `ios/arm64 requires external (cgo) linking`. darwin (non-iOS) internal-links fine, which is exactly why #117 worked and iOS can't.

## Why the original check was a false positive
The spec's iOS proof was `GOOS=ios CGO_ENABLED=0 go build std` passing — but `go build std` compiles packages without linking and without pulling in purego, sidestepping both blockers. The erratum documents the correct check (build the real package with its FFI dep, *and* link a binary) as a lesson for future platform specs.

## Result
- **No source change.** Both iOS and Android backends stay Cgo (different reasons; both unfixable from this package).
- Spec status → **Accepted, negative result**; §4 (iOS blockers), §5 (Android), §6 (false-positive post-mortem) added.
- Follow-up: closing #125 as not-feasible with this evidence; #126 (Android) reasoning stands.

Docs-only.