### PR TITLE
clipboard: add custom-format registry (Register, ReadAs) (#17)

### DIFF
--- a/format.go
+++ b/format.go
@@ -1,0 +1,85 @@
+// Copyright 2021 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+package clipboard
+
+import (
+	"errors"
+	"sync"
+)
+
+// ErrNoData is returned by ReadAs when the clipboard holds no data in the
+// requested format.
+var ErrNoData = errors.New("clipboard: no data available for the given format")
+
+// The custom-format registry maps a portable MIME-type string to an opaque
+// Format token (and back). The built-in FmtText and FmtImage tokens are not
+// part of the registry; custom tokens are allocated above them. Keeping the
+// MIME identity here, behind the Format token, means no platform- or
+// Cgo-specific type ever leaks into user code: each backend resolves the MIME
+// string to its own native clipboard type (see formatMIME).
+var (
+	registryMu   sync.RWMutex
+	mimeToFormat = map[string]Format{}
+	formatToMIME = map[Format]string{}
+	// nextFormat is the next custom token to hand out. Custom formats start
+	// immediately above the built-in tokens so they never collide with
+	// FmtText/FmtImage.
+	nextFormat = FmtImage + 1
+)
+
+// Register maps a MIME type to a Format token usable with Read, Write, and
+// Watch. It is idempotent: Register returns the same token for the same MIME
+// string, so it is safe to call repeatedly. Register is safe to call before
+// Init and concurrently from multiple goroutines.
+//
+// The returned token denotes a raw, passthrough format: unlike FmtImage (which
+// transcodes between PNG and each platform's native image type), Read and Write
+// move the exact bytes to and from the clipboard under the MIME type's native
+// representation, with no encoding or conversion. Registering "image/png" is
+// therefore distinct from the built-in FmtImage.
+func Register(mime string) Format {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	if f, ok := mimeToFormat[mime]; ok {
+		return f
+	}
+	f := nextFormat
+	nextFormat++
+	mimeToFormat[mime] = f
+	formatToMIME[f] = mime
+	return f
+}
+
+// formatMIME returns the MIME string a custom Format token was registered with.
+// The boolean result is false for the built-in FmtText/FmtImage tokens and for
+// any token that was never returned by Register. Backends call this in their
+// read/write default case to resolve a custom token to a native clipboard type.
+func formatMIME(f Format) (string, bool) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	mime, ok := formatToMIME[f]
+	return mime, ok
+}
+
+// ReadAs reads the clipboard contents for the format f and decodes them into a
+// typed value with decode. It returns the zero value of T and ErrNoData when
+// the clipboard holds nothing in that format, or the zero value and decode's
+// error when decoding fails.
+//
+// ReadAs relocates the typed-decode idea to where Go generics actually compose
+// — a free helper over Read — instead of a heterogeneous registry that would
+// have to erase every decode function to any. It is also the seam where an
+// error-returning, capability-aware read path can grow without changing the
+// byte-oriented Read.
+func ReadAs[T any](f Format, decode func([]byte) (T, error)) (T, error) {
+	var zero T
+	buf := Read(f)
+	if buf == nil {
+		return zero, ErrNoData
+	}
+	return decode(buf)
+}

--- a/format_internal_test.go
+++ b/format_internal_test.go
@@ -1,0 +1,92 @@
+// Copyright 2021 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+package clipboard
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+func TestRegister(t *testing.T) {
+	// Idempotent: the same MIME always maps to the same token.
+	html := Register("text/html")
+	if got := Register("text/html"); got != html {
+		t.Fatalf("Register is not idempotent: first %v, second %v", html, got)
+	}
+
+	// Distinct MIME types map to distinct tokens.
+	pdf := Register("application/pdf")
+	if pdf == html {
+		t.Fatalf("distinct MIME types share a token: html=%v pdf=%v", html, pdf)
+	}
+
+	// Custom tokens never collide with the built-in formats.
+	for _, builtin := range []Format{FmtText, FmtImage} {
+		if html == builtin || pdf == builtin {
+			t.Fatalf("custom token collides with a built-in: html=%v pdf=%v builtin=%v", html, pdf, builtin)
+		}
+	}
+
+	// formatMIME round-trips a custom token back to its MIME string.
+	if mime, ok := formatMIME(html); !ok || mime != "text/html" {
+		t.Fatalf("formatMIME(html) = (%q, %v), want (\"text/html\", true)", mime, ok)
+	}
+
+	// formatMIME reports false for the built-ins and for unregistered tokens.
+	if _, ok := formatMIME(FmtText); ok {
+		t.Fatalf("formatMIME(FmtText) reported ok; built-ins are not in the registry")
+	}
+	if _, ok := formatMIME(FmtImage); ok {
+		t.Fatalf("formatMIME(FmtImage) reported ok; built-ins are not in the registry")
+	}
+	if _, ok := formatMIME(Format(1 << 20)); ok {
+		t.Fatalf("formatMIME reported ok for an unregistered token")
+	}
+}
+
+func TestRegisterConcurrent(t *testing.T) {
+	const mime = "application/x.concurrent-test"
+	const n = 64
+
+	var wg sync.WaitGroup
+	tokens := make([]Format, n)
+	for i := range tokens {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			tokens[i] = Register(mime)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, got := range tokens {
+		if got != tokens[0] {
+			t.Fatalf("concurrent Register returned different tokens: tokens[%d]=%v tokens[0]=%v", i, got, tokens[0])
+		}
+	}
+}
+
+func TestReadAsNoData(t *testing.T) {
+	// A freshly registered format that was never written holds no data, so
+	// ReadAs must report ErrNoData and must not invoke decode.
+	f := Register("application/x.readas-nodata-test")
+	called := false
+	v, err := ReadAs(f, func(b []byte) (int, error) {
+		called = true
+		return len(b), nil
+	})
+	if !errors.Is(err, ErrNoData) {
+		t.Fatalf("ReadAs error = %v, want ErrNoData", err)
+	}
+	if v != 0 {
+		t.Fatalf("ReadAs value = %v, want zero value", v)
+	}
+	if called {
+		t.Fatalf("decode was called despite no data being available")
+	}
+}


### PR DESCRIPTION
First PR of the custom clipboard formats design ([spec](../blob/main/specs/custom-clipboard-formats.md)), refs #17, #40.

## Scope (core only)

Platform-agnostic foundation; **no backend changes**. Each backend adopts the seam in its own follow-up PR (darwin, X11/Linux+BSD, Wayland, Windows, Android, iOS, nocgo).

- `Register(mime string) Format` — idempotent MIME → opaque `Format` token, allocated above the built-in `FmtText`/`FmtImage`. Safe before `Init` and concurrently.
- `ReadAs[T any](f Format, decode func([]byte) (T, error)) (T, error)` — typed decode over `Read`; returns `ErrNoData` when nothing is on the clipboard for `f`.
- `ErrNoData` — exported sentinel.
- `formatMIME(Format) (string, bool)` — reverse lookup backends will call in their read/write `default` case to resolve a token to a native clipboard type.

Custom tokens are **raw passthrough** (no conversion), distinct from `FmtImage`'s PNG transcode — registering `"image/png"` is not `FmtImage`.

## Until backends adopt it

`Read`/`Write`/`Watch` of a custom token degrade to nil on every platform (unchanged behavior). Real round-trips land per-backend next.

## Tests

`format_internal_test.go`: idempotency, distinct tokens, no collision with built-ins, `formatMIME` round-trip + built-in/unknown handling, concurrent `Register` (race), and `ReadAs` → `ErrNoData` without invoking decode. Passes under `-race` and `CGO_ENABLED=0`.