### PR TITLE
darwin: adopt custom clipboard formats via raw pasteboard types (#17)

### DIFF
--- a/clipboard_custom_darwin_test.go
+++ b/clipboard_custom_darwin_test.go
@@ -1,0 +1,13 @@
+// Copyright 2021 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+//go:build darwin && !ios
+
+package clipboard_test
+
+import "testing"
+
+func TestCustomFormatRoundTrip(t *testing.T) { customRoundTrip(t) }

--- a/clipboard_custom_test.go
+++ b/clipboard_custom_test.go
@@ -1,0 +1,57 @@
+// Copyright 2021 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+package clipboard_test
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"golang.design/x/clipboard"
+)
+
+// customRoundTrip writes and reads back a raw custom format, asserting the
+// bytes survive verbatim (no encoding or conversion) and that ReadAs decodes
+// them. Each platform backend that adopts the custom-format seam wires this
+// helper into a build-tagged TestCustomFormatRoundTrip; the helper itself is
+// platform-agnostic.
+func customRoundTrip(t *testing.T) {
+	t.Helper()
+
+	if degradesWithoutCgo() {
+		if val, ok := os.LookupEnv("CGO_ENABLED"); ok && val == "0" {
+			t.Skip("CGO_ENABLED is set to 0")
+		}
+	}
+
+	f := clipboard.Register("application/x.golang-design.clipboard-test")
+
+	// Raw bytes including a NUL and non-UTF-8 bytes: a passthrough format must
+	// preserve them exactly, unlike FmtText (UTF-8) or FmtImage (PNG).
+	want := []byte{0x00, 0x01, 0x02, 0xff, 0xfe, 'h', 'i', 0x00, 0x80}
+	clipboard.Write(f, want)
+
+	got := clipboard.Read(f)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("custom format round-trip mismatch:\n want %v\n  got %v", want, got)
+	}
+
+	// ReadAs decodes the same bytes through a caller-supplied function.
+	n, err := clipboard.ReadAs(f, func(b []byte) (int, error) { return len(b), nil })
+	if err != nil {
+		t.Fatalf("ReadAs returned error: %v", err)
+	}
+	if n != len(want) {
+		t.Fatalf("ReadAs decoded length = %d, want %d", n, len(want))
+	}
+
+	// A different, unwritten custom format reads back as nil / ErrNoData.
+	other := clipboard.Register("application/x.golang-design.clipboard-test-absent")
+	if got := clipboard.Read(other); got != nil {
+		t.Fatalf("unwritten custom format should read nil, got %v", got)
+	}
+}

--- a/clipboard_darwin.go
+++ b/clipboard_darwin.go
@@ -30,19 +30,21 @@ var (
 
 	class_NSPasteboard      = objc.GetClass("NSPasteboard")
 	class_NSData            = objc.GetClass("NSData")
+	class_NSString          = objc.GetClass("NSString")
 	class_NSAutoreleasePool = objc.GetClass("NSAutoreleasePool")
 
-	sel_alloc               = objc.RegisterName("alloc")
-	sel_init                = objc.RegisterName("init")
-	sel_drain               = objc.RegisterName("drain")
-	sel_generalPasteboard   = objc.RegisterName("generalPasteboard")
-	sel_length              = objc.RegisterName("length")
-	sel_getBytesLength      = objc.RegisterName("getBytes:length:")
-	sel_dataForType         = objc.RegisterName("dataForType:")
-	sel_clearContents       = objc.RegisterName("clearContents")
-	sel_setDataForType      = objc.RegisterName("setData:forType:")
-	sel_dataWithBytesLength = objc.RegisterName("dataWithBytes:length:")
-	sel_changeCount         = objc.RegisterName("changeCount")
+	sel_alloc                = objc.RegisterName("alloc")
+	sel_init                 = objc.RegisterName("init")
+	sel_drain                = objc.RegisterName("drain")
+	sel_generalPasteboard    = objc.RegisterName("generalPasteboard")
+	sel_length               = objc.RegisterName("length")
+	sel_getBytesLength       = objc.RegisterName("getBytes:length:")
+	sel_dataForType          = objc.RegisterName("dataForType:")
+	sel_clearContents        = objc.RegisterName("clearContents")
+	sel_setDataForType       = objc.RegisterName("setData:forType:")
+	sel_dataWithBytesLength  = objc.RegisterName("dataWithBytes:length:")
+	sel_stringWithUTF8String = objc.RegisterName("stringWithUTF8String:")
+	sel_changeCount          = objc.RegisterName("changeCount")
 )
 
 func must(sym uintptr, err error) uintptr {
@@ -89,8 +91,13 @@ func read(t Format) (buf []byte, err error) {
 		return clipboard_read_string(), nil
 	case FmtImage:
 		return clipboard_read_image(), nil
+	default:
+		mime, ok := formatMIME(t)
+		if !ok {
+			return nil, errUnsupported
+		}
+		return clipboard_read_custom(mime), nil
 	}
-	return nil, errUnavailable
 }
 
 // write writes the given data to clipboard and
@@ -111,7 +118,11 @@ func write(t Format, buf []byte) (<-chan struct{}, error) {
 			ok = clipboard_write_image(buf)
 		}
 	default:
-		return nil, errUnsupported
+		mime, found := formatMIME(t)
+		if !found {
+			return nil, errUnsupported
+		}
+		ok = clipboard_write_custom(mime, buf)
 	}
 	if !ok {
 		return nil, errUnavailable
@@ -225,6 +236,35 @@ func clipboard_write_string(buf []byte) bool {
 	runtime.KeepAlive(buf)
 	pasteboard.Send(sel_clearContents)
 	return pasteboard.Send(sel_setDataForType, data, _NSPasteboardTypeString) != 0
+}
+
+// nsString builds an autoreleased NSString from a Go string, used as a custom
+// pasteboard type. It must be called inside an autorelease pool (read/write
+// custom both install one) so the temporary string is reclaimed.
+func nsString(s string) objc.ID {
+	b := append([]byte(s), 0) // NUL-terminate for stringWithUTF8String:
+	str := objc.ID(class_NSString).Send(sel_stringWithUTF8String, unsafe.SliceData(b))
+	runtime.KeepAlive(b)
+	return str
+}
+
+// clipboard_read_custom returns the raw bytes stored under the given MIME type
+// (used as the pasteboard type verbatim), or nil if no such data is present.
+func clipboard_read_custom(mime string) []byte {
+	defer newAutoreleasePool()()
+	pasteboard := objc.ID(class_NSPasteboard).Send(sel_generalPasteboard)
+	return nsdataBytes(pasteboard.Send(sel_dataForType, nsString(mime)))
+}
+
+// clipboard_write_custom stores buf verbatim under the given MIME type with no
+// conversion (raw passthrough), replacing the current clipboard contents.
+func clipboard_write_custom(mime string, buf []byte) bool {
+	defer newAutoreleasePool()()
+	pasteboard := objc.ID(class_NSPasteboard).Send(sel_generalPasteboard)
+	data := objc.ID(class_NSData).Send(sel_dataWithBytesLength, unsafe.SliceData(buf), len(buf))
+	runtime.KeepAlive(buf)
+	pasteboard.Send(sel_clearContents)
+	return pasteboard.Send(sel_setDataForType, data, nsString(mime)) != 0
 }
 
 func clipboard_change_count() int {


### PR DESCRIPTION
Backend PR of the custom clipboard formats design ([spec](../blob/main/specs/custom-clipboard-formats.md)). Builds on #128. Refs #17, #40.

## Scope (macOS backend)

- `read`/`write` `default` case resolves a custom `Format` token to its MIME string via `formatMIME`, then stores/reads the bytes **verbatim** under that string as an `NSPasteboardType` — raw passthrough, no encoding/conversion (contrast `FmtImage`'s PNG↔TIFF transcode).
- New helpers: `nsString` (Go string → autoreleased `NSString` pasteboard type), `clipboard_read_custom`, `clipboard_write_custom`.
- `Watch` of a custom format works for free (it polls `Read`).
- Built-in `FmtText`/`FmtImage` paths untouched.

## Tests

- `clipboard_custom_test.go`: platform-agnostic `customRoundTrip` helper (round-trips raw bytes incl. NUL + non-UTF-8 through a registered format and `ReadAs`; verifies an unwritten format reads nil).
- `clipboard_custom_darwin_test.go`: `TestCustomFormatRoundTrip` runs it on macOS.

Subsequent PRs wire the same helper into X11/Linux+BSD, Wayland, Windows, and the mobile/nocgo degrade paths.