### PR TITLE
linux/bsd: adopt custom clipboard formats on the X11 backend (#17)

### DIFF
--- a/clipboard_bsd.go
+++ b/clipboard_bsd.go
@@ -45,8 +45,14 @@ func read(t Format) (buf []byte, err error) {
 		return x11Read("UTF8_STRING")
 	case FmtImage:
 		return x11Read("image/png")
+	default:
+		mime, ok := formatMIME(t)
+		if !ok {
+			return nil, errUnsupported
+		}
+		// On X11 a MIME type is used directly as the target atom.
+		return x11Read(mime)
 	}
-	return nil, errUnsupported
 }
 
 func write(t Format, buf []byte) (<-chan struct{}, error) {
@@ -55,8 +61,13 @@ func write(t Format, buf []byte) (<-chan struct{}, error) {
 		return x11Write("UTF8_STRING", buf)
 	case FmtImage:
 		return x11Write("image/png", buf)
+	default:
+		mime, ok := formatMIME(t)
+		if !ok {
+			return nil, errUnsupported
+		}
+		return x11Write(mime, buf)
 	}
-	return nil, errUnsupported
 }
 
 func watch(ctx context.Context, t Format) <-chan []byte {

--- a/clipboard_custom_bsd_test.go
+++ b/clipboard_custom_bsd_test.go
@@ -1,0 +1,15 @@
+// Copyright 2021 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+//go:build (freebsd || openbsd || netbsd) && !android
+
+package clipboard_test
+
+import "testing"
+
+// The BSDs share the X11 backend with Linux. CI only builds (no X server), so
+// this exercises compilation; it runs the round-trip locally on a BSD with X11.
+func TestCustomFormatRoundTrip(t *testing.T) { customRoundTrip(t) }

--- a/clipboard_custom_linux_test.go
+++ b/clipboard_custom_linux_test.go
@@ -1,0 +1,24 @@
+// Copyright 2021 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+//go:build linux && !android
+
+package clipboard_test
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCustomFormatRoundTrip(t *testing.T) {
+	// This PR wires custom formats into the X11 backend only. Under Wayland
+	// (e.g. the headless-sway CI job) the data-control backend is used, where
+	// custom-format support lands in a separate PR; skip there for now.
+	if os.Getenv("WAYLAND_DISPLAY") != "" {
+		t.Skip("Wayland custom-format support lands in a separate PR")
+	}
+	customRoundTrip(t)
+}

--- a/clipboard_linux.go
+++ b/clipboard_linux.go
@@ -61,8 +61,14 @@ func read(t Format) (buf []byte, err error) {
 		return x11Read("UTF8_STRING")
 	case FmtImage:
 		return x11Read("image/png")
+	default:
+		mime, ok := formatMIME(t)
+		if !ok {
+			return nil, errUnsupported
+		}
+		// On X11 a MIME type is used directly as the target atom.
+		return x11Read(mime)
 	}
-	return nil, errUnsupported
 }
 
 func write(t Format, buf []byte) (<-chan struct{}, error) {
@@ -74,8 +80,13 @@ func write(t Format, buf []byte) (<-chan struct{}, error) {
 		return x11Write("UTF8_STRING", buf)
 	case FmtImage:
 		return x11Write("image/png", buf)
+	default:
+		mime, ok := formatMIME(t)
+		if !ok {
+			return nil, errUnsupported
+		}
+		return x11Write(mime, buf)
 	}
-	return nil, errUnsupported
 }
 
 func watch(ctx context.Context, t Format) <-chan []byte {


### PR DESCRIPTION
Backend PR of the custom clipboard formats design ([spec](../blob/main/specs/custom-clipboard-formats.md)). Builds on #128/#129. Refs #17, #40.

## Scope (X11 backend — Linux + BSD)

- `read`/`write` `default` case resolves a custom `Format` token to its MIME string and uses it **directly as the X11 target atom** (`x11Read(mime)` / `x11Write(mime, buf)`), which are already MIME-shaped (`UTF8_STRING`, `image/png`). Raw passthrough, no conversion.
- `Watch` works for free (polls `Read`).
- Built-in `FmtText`/`FmtImage` unchanged.

Shared by Linux and the BSDs (same `clipboard_x11.go`).

## Out of scope

The Wayland data-control backend is untouched — custom support lands in its own PR. The Linux round-trip test skips when `WAYLAND_DISPLAY` is set so the headless-sway CI job stays green until then.

## Tests

- `clipboard_custom_linux_test.go`: runs `customRoundTrip` on the X11 ubuntu job; skips under Wayland.
- `clipboard_custom_bsd_test.go`: BSD CI is build-only, so this verifies compilation; runs locally on a BSD with X11.

Verified locally via cross-compile + test-compile for `linux/amd64`, `freebsd/amd64`, `openbsd/amd64`.