### PR TITLE
docs: document custom clipboard formats and per-platform support (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ import "golang.design/x/clipboard"
 - Cross platform supports: **macOS, Linux (X11 and Wayland), Windows, BSD (X11), iOS, and Android**
 - Copy/paste UTF-8 text
 - Copy/paste PNG encoded images (Desktop-only)
+- Register and copy/paste custom MIME-typed formats (Desktop-only, raw passthrough)
 - Command `gclip` as a demo application
 - Mobile app `gclip-gui` as a demo application
 
@@ -88,6 +89,34 @@ for data := range ch {
       }
 }
 ```
+
+Beyond the built-in `FmtText` and `FmtImage`, you can register a custom
+format by its MIME type and use the returned token with `Read`, `Write`,
+and `Watch`. Custom formats are **raw passthrough**: the exact bytes are
+moved to and from the clipboard under that MIME type with no encoding or
+conversion (unlike `FmtImage`, which transcodes PNG). `Register` is
+idempotent and safe to call before `Init`:
+
+```go
+html := clipboard.Register("text/html")
+clipboard.Write(html, []byte("<b>hi</b>"))
+b := clipboard.Read(html)
+
+// Or decode into a typed value with ReadAs:
+doc, err := clipboard.ReadAs(html, func(b []byte) (*Node, error) {
+      return parseHTML(b)
+})
+```
+
+Custom-format support is per platform:
+
+- **macOS, Windows, Linux/X11, BSD/X11:** full read/write/watch round-trip.
+- **Linux/Wayland (data-control):** read/write interoperate with other apps;
+  a process does not observe its *own* just-set custom selection (a
+  data-control limitation).
+- **iOS, Android, and CGO-disabled builds:** `Register` works, but `Read`
+  returns `nil` and `Write` is a no-op for custom formats — they degrade
+  gracefully like the rest of the API.
 
 ## Demos
 

--- a/clipboard.go
+++ b/clipboard.go
@@ -67,6 +67,14 @@ all supported ones):
 		}
 	}
 
+Besides the built-in FmtText and FmtImage, Register maps a MIME type to a
+custom Format token usable with Read, Write, and Watch. Custom formats are
+raw passthrough: the exact bytes are exchanged under that MIME type with no
+conversion. Use ReadAs to decode into a typed value. Custom formats are
+supported on the desktop backends (macOS, Windows, Linux/X11, BSD/X11, and
+Linux/Wayland for cross-application exchange); on iOS, Android, and
+CGO-disabled builds they degrade gracefully like the rest of the API.
+
 # Platform-specific caveats
 
 On Linux/X11 the clipboard follows the X11 selection-ownership model:

--- a/clipboard_android.go
+++ b/clipboard_android.go
@@ -48,6 +48,8 @@ func read(t Format) (buf []byte, err error) {
 	case FmtImage:
 		return nil, errUnsupported
 	default:
+		// The Android bridge handles only text; images and custom MIME
+		// formats registered via Register degrade to nil here.
 		return nil, errUnsupported
 	}
 }
@@ -72,6 +74,8 @@ func write(t Format, buf []byte) (<-chan struct{}, error) {
 	case FmtImage:
 		return nil, errUnsupported
 	default:
+		// The Android bridge handles only text; images and custom MIME
+		// formats registered via Register degrade to a no-op here.
 		return nil, errUnsupported
 	}
 }

--- a/clipboard_ios.go
+++ b/clipboard_ios.go
@@ -33,6 +33,8 @@ func read(t Format) (buf []byte, err error) {
 	case FmtImage:
 		return nil, errUnsupported
 	default:
+		// The iOS bridge handles only text; images and custom MIME formats
+		// registered via Register degrade to nil here.
 		return nil, errUnsupported
 	}
 }
@@ -50,6 +52,8 @@ func write(t Format, buf []byte) (<-chan struct{}, error) {
 	case FmtImage:
 		return nil, errUnsupported
 	default:
+		// The iOS bridge handles only text; images and custom MIME formats
+		// registered via Register degrade to a no-op here.
 		return nil, errUnsupported
 	}
 }

--- a/clipboard_nocgo.go
+++ b/clipboard_nocgo.go
@@ -8,6 +8,10 @@ func initialize() error {
 	return errNoCgo
 }
 
+// read returns errNoCgo for every format, including custom ones registered via
+// Register: in a CGO-disabled build the clipboard is unavailable, so the public
+// API degrades gracefully (Read returns nil, Write returns nil) rather than
+// panicking.
 func read(t Format) (buf []byte, err error) {
 	return nil, errNoCgo
 }


### PR DESCRIPTION
Final PR of the custom clipboard formats design ([spec](../blob/main/specs/custom-clipboard-formats.md)). Builds on #128–#132. Closes the #17 rollout.

## Scope (docs + explicit graceful degradation)

- **README:** Features bullet, a custom-formats usage section (`Register` + `ReadAs`), and a per-platform support matrix — including the Wayland same-process caveat (cross-app interop works; a process doesn't observe its own just-set custom selection).
- **Package godoc:** a paragraph covering `Register`/`ReadAs` and where custom formats are supported vs. degrade.
- **android / iOS / nocgo:** comments on the read/write `default` case making explicit that custom MIME formats degrade gracefully (`Read` → nil, `Write` → no-op), so every backend's handling of custom tokens is documented in code.

No functional change to the mobile/nocgo backends — `Register` already works everywhere (shared) and these platforms already returned `errUnsupported`/`errNoCgo` for custom tokens; this records that as the intended behavior.

## Rollout summary

| Backend | Custom formats |
|---|---|
| macOS, Windows, Linux/X11, BSD/X11 | full read/write/watch round-trip |
| Linux/Wayland (data-control) | cross-application read/write (interop-tested) |
| iOS, Android, CGO-disabled | graceful degradation |