### PR TITLE
clipboard: add Formats() and Format.MIME() core (#89)

### DIFF
--- a/clipboard_android.go
+++ b/clipboard_android.go
@@ -28,6 +28,10 @@ import (
 
 func initialize() error { return nil }
 
+// enumerateFormats reports the formats on the clipboard. The Android bridge
+// exposes only text and no enumeration API, so Formats() returns empty.
+func enumerateFormats() []Format { return nil }
+
 func read(t Format) (buf []byte, err error) {
 	switch t {
 	case FmtText:

--- a/clipboard_bsd.go
+++ b/clipboard_bsd.go
@@ -39,6 +39,11 @@ func initialize() error {
 	return nil
 }
 
+// enumerateFormats reports the formats currently on the clipboard. Implemented
+// in a follow-up PR (shared X11 path); for now it returns nil so Formats()
+// degrades to empty.
+func enumerateFormats() []Format { return nil }
+
 func read(t Format) (buf []byte, err error) {
 	switch t {
 	case FmtText:

--- a/clipboard_darwin.go
+++ b/clipboard_darwin.go
@@ -85,6 +85,10 @@ func newAutoreleasePool() (drain func()) {
 	}
 }
 
+// enumerateFormats reports the formats currently on the clipboard. Implemented
+// in a follow-up PR; for now it returns nil so Formats() degrades to empty.
+func enumerateFormats() []Format { return nil }
+
 func read(t Format) (buf []byte, err error) {
 	switch t {
 	case FmtText:

--- a/clipboard_ios.go
+++ b/clipboard_ios.go
@@ -26,6 +26,10 @@ import (
 
 func initialize() error { return nil }
 
+// enumerateFormats reports the formats on the clipboard. The iOS bridge exposes
+// only text and no enumeration API, so Formats() returns empty.
+func enumerateFormats() []Format { return nil }
+
 func read(t Format) (buf []byte, err error) {
 	switch t {
 	case FmtText:

--- a/clipboard_linux.go
+++ b/clipboard_linux.go
@@ -52,6 +52,11 @@ func initialize() error {
 	return nil
 }
 
+// enumerateFormats reports the formats currently on the clipboard. Implemented
+// in follow-up PRs (X11 and Wayland); for now it returns nil so Formats()
+// degrades to empty.
+func enumerateFormats() []Format { return nil }
+
 func read(t Format) (buf []byte, err error) {
 	if useWayland {
 		return wlRead(t)

--- a/clipboard_nocgo.go
+++ b/clipboard_nocgo.go
@@ -8,6 +8,10 @@ func initialize() error {
 	return errNoCgo
 }
 
+// enumerateFormats reports the formats on the clipboard. In a CGO-disabled
+// build the clipboard is unavailable, so Formats() returns empty.
+func enumerateFormats() []Format { return nil }
+
 // read returns errNoCgo for every format, including custom ones registered via
 // Register: in a CGO-disabled build the clipboard is unavailable, so the public
 // API degrades gracefully (Read returns nil, Write returns nil) rather than

--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -316,6 +316,10 @@ func writeCustom(format uintptr, buf []byte) error {
 	return nil
 }
 
+// enumerateFormats reports the formats currently on the clipboard. Implemented
+// in a follow-up PR; for now it returns nil so Formats() degrades to empty.
+func enumerateFormats() []Format { return nil }
+
 func read(t Format) (buf []byte, err error) {
 	// On Windows, OpenClipboard and CloseClipboard must be executed on
 	// the same thread. Thus, lock the OS thread for further execution.

--- a/format.go
+++ b/format.go
@@ -8,6 +8,7 @@ package clipboard
 
 import (
 	"errors"
+	"slices"
 	"sync"
 )
 
@@ -63,6 +64,63 @@ func formatMIME(f Format) (string, bool) {
 	defer registryMu.RUnlock()
 	mime, ok := formatToMIME[f]
 	return mime, ok
+}
+
+// MIME returns the MIME type that the Format f denotes. For the built-in
+// formats it returns a canonical type ("text/plain;charset=utf-8" for FmtText,
+// "image/png" for FmtImage); for a custom format it returns the string passed
+// to Register; for a token that was never registered it returns "".
+func (f Format) MIME() string {
+	switch f {
+	case FmtText:
+		return "text/plain;charset=utf-8"
+	case FmtImage:
+		return "image/png"
+	}
+	if mime, ok := formatMIME(f); ok {
+		return mime
+	}
+	return ""
+}
+
+// Formats reports the formats currently available on the clipboard, in a stable
+// order: FmtText then FmtImage (when present), followed by custom formats in
+// registration order. Custom MIME types discovered on the clipboard are
+// registered on demand, so every returned token can be passed straight to Read
+// (and its identity inspected with Format.MIME).
+//
+// It returns an empty slice when the clipboard is empty or unavailable — for
+// example on iOS/Android or in a CGO-disabled build, where it degrades like the
+// rest of the API rather than panicking.
+func Formats() []Format {
+	lock.Lock()
+	defer lock.Unlock()
+	return normalizeFormats(enumerateFormats())
+}
+
+// normalizeFormats de-duplicates tokens and returns them in a stable order:
+// the built-ins first (FmtText, then FmtImage), then custom tokens in ascending
+// token value, which is their registration order.
+func normalizeFormats(in []Format) []Format {
+	seen := make(map[Format]bool, len(in))
+	for _, f := range in {
+		seen[f] = true
+	}
+
+	var out []Format
+	for _, b := range []Format{FmtText, FmtImage} {
+		if seen[b] {
+			out = append(out, b)
+			delete(seen, b)
+		}
+	}
+
+	custom := make([]Format, 0, len(seen))
+	for f := range seen {
+		custom = append(custom, f)
+	}
+	slices.Sort(custom)
+	return append(out, custom...)
 }
 
 // ReadAs reads the clipboard contents for the format f and decodes them into a

--- a/format_internal_test.go
+++ b/format_internal_test.go
@@ -90,3 +90,40 @@ func TestReadAsNoData(t *testing.T) {
 		t.Fatalf("decode was called despite no data being available")
 	}
 }
+
+func TestFormatMIME(t *testing.T) {
+	if got := FmtText.MIME(); got != "text/plain;charset=utf-8" {
+		t.Fatalf("FmtText.MIME() = %q", got)
+	}
+	if got := FmtImage.MIME(); got != "image/png" {
+		t.Fatalf("FmtImage.MIME() = %q", got)
+	}
+	if got := Register("application/x.mime-test").MIME(); got != "application/x.mime-test" {
+		t.Fatalf("custom MIME() = %q, want application/x.mime-test", got)
+	}
+	if got := Format(1 << 20).MIME(); got != "" {
+		t.Fatalf("unregistered MIME() = %q, want empty", got)
+	}
+}
+
+func TestNormalizeFormats(t *testing.T) {
+	a := Register("application/x.normalize-a")
+	b := Register("application/x.normalize-b") // registered after a, so a < b
+
+	// Out of order, with duplicates and both built-ins.
+	got := normalizeFormats([]Format{b, FmtImage, a, FmtText, a, FmtImage, b})
+	want := []Format{FmtText, FmtImage, a, b}
+	if len(got) != len(want) {
+		t.Fatalf("normalizeFormats len = %d (%v), want %d (%v)", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("normalizeFormats = %v, want %v", got, want)
+		}
+	}
+
+	// Empty input yields no formats.
+	if got := normalizeFormats(nil); len(got) != 0 {
+		t.Fatalf("normalizeFormats(nil) = %v, want empty", got)
+	}
+}


### PR DESCRIPTION
First PR of the format-enumeration rollout ([spec](../blob/main/specs/clipboard-format-enumeration.md), Option B). Refs #89.

## Scope (core only)

- **`func (f Format) MIME() string`** — a Format's MIME identity: `text/plain;charset=utf-8` / `image/png` for built-ins, the registered string for customs, `""` for unregistered.
- **`func Formats() []Format`** — formats currently on the clipboard, normalized via `normalizeFormats` (built-ins first, then custom tokens in registration order, de-duplicated).
- **`enumerateFormats()` seam** added to every backend, returning `nil` for now — so `Formats()` compiles and degrades to empty everywhere until the per-platform enumeration lands. Mobile/nocgo keep the `nil` stub permanently.

## Next

Per-backend `enumerateFormats()`: X11/BSD (`TARGETS`), Wayland (offered MIMEs), Windows (`EnumClipboardFormats`), macOS (`NSPasteboard types`) — each its own PR.

## Tests

`Format.MIME()` for built-in/custom/unregistered tokens; `normalizeFormats` ordering + dedup + empty. Passes under `-race` and `CGO_ENABLED=0`; cross-compiles for linux/windows/freebsd/openbsd.