### PR TITLE
linux/bsd: implement Formats() enumeration on the X11 backend (#89)

### DIFF
--- a/clipboard_bsd.go
+++ b/clipboard_bsd.go
@@ -39,10 +39,9 @@ func initialize() error {
 	return nil
 }
 
-// enumerateFormats reports the formats currently on the clipboard. Implemented
-// in a follow-up PR (shared X11 path); for now it returns nil so Formats()
-// degrades to empty.
-func enumerateFormats() []Format { return nil }
+// enumerateFormats reports the formats currently on the clipboard via the shared
+// X11 TARGETS enumeration.
+func enumerateFormats() []Format { return x11EnumerateFormats() }
 
 func read(t Format) (buf []byte, err error) {
 	switch t {

--- a/clipboard_enumerate_bsd_test.go
+++ b/clipboard_enumerate_bsd_test.go
@@ -1,0 +1,15 @@
+// Copyright 2021 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+//go:build (freebsd || openbsd || netbsd) && !android
+
+package clipboard_test
+
+import "testing"
+
+// The BSDs share the X11 enumeration with Linux. CI only builds (no X server),
+// so this exercises compilation; it runs the round-trip locally on a BSD/X11.
+func TestFormatsEnumerate(t *testing.T) { enumerateRoundTrip(t) }

--- a/clipboard_enumerate_linux_test.go
+++ b/clipboard_enumerate_linux_test.go
@@ -1,0 +1,23 @@
+// Copyright 2021 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+//go:build linux && !android
+
+package clipboard_test
+
+import (
+	"os"
+	"testing"
+)
+
+func TestFormatsEnumerate(t *testing.T) {
+	// This PR implements enumeration on the X11 backend. Wayland enumeration
+	// lands in a follow-up PR; skip there for now.
+	if os.Getenv("WAYLAND_DISPLAY") != "" {
+		t.Skip("Wayland enumeration lands in a separate PR")
+	}
+	enumerateRoundTrip(t)
+}

--- a/clipboard_enumerate_test.go
+++ b/clipboard_enumerate_test.go
@@ -1,0 +1,70 @@
+// Copyright 2021 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+package clipboard_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"golang.design/x/clipboard"
+)
+
+// enumerateRoundTrip writes known formats and asserts Formats() reports them
+// with the right MIME identity. Platform backends that implement enumeration
+// wire this into a build-tagged TestFormatsEnumerate; the helper itself is
+// platform-agnostic.
+func enumerateRoundTrip(t *testing.T) {
+	t.Helper()
+
+	if degradesWithoutCgo() {
+		if val, ok := os.LookupEnv("CGO_ENABLED"); ok && val == "0" {
+			t.Skip("CGO_ENABLED is set to 0")
+		}
+	}
+
+	// A built-in format is reported after it is written.
+	clipboard.Write(clipboard.FmtText, []byte("enumerate-text"))
+	if fs := waitForFormat(clipboard.FmtText); !containsFormat(fs, clipboard.FmtText) {
+		t.Fatalf("Formats() after writing FmtText = %v, want it to include FmtText", fs)
+	}
+
+	// A custom MIME type is discovered and reported, and the returned token
+	// carries its MIME identity.
+	html := clipboard.Register("text/html")
+	clipboard.Write(html, []byte("<b>enumerate</b>"))
+	fs := waitForFormat(html)
+	if !containsFormat(fs, html) {
+		t.Fatalf("Formats() after writing text/html = %v, want it to include the html token", fs)
+	}
+	if html.MIME() != "text/html" {
+		t.Fatalf("html token MIME() = %q, want text/html", html.MIME())
+	}
+}
+
+func containsFormat(fs []clipboard.Format, want clipboard.Format) bool {
+	for _, f := range fs {
+		if f == want {
+			return true
+		}
+	}
+	return false
+}
+
+// waitForFormat polls Formats() until it includes want (or a timeout), absorbing
+// any brief delay between a write taking effect and a fresh enumeration seeing
+// it.
+func waitForFormat(want clipboard.Format) []clipboard.Format {
+	var fs []clipboard.Format
+	for i := 0; i < 50; i++ {
+		if fs = clipboard.Formats(); containsFormat(fs, want) {
+			return fs
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return fs
+}

--- a/clipboard_linux.go
+++ b/clipboard_linux.go
@@ -52,10 +52,15 @@ func initialize() error {
 	return nil
 }
 
-// enumerateFormats reports the formats currently on the clipboard. Implemented
-// in follow-up PRs (X11 and Wayland); for now it returns nil so Formats()
-// degrades to empty.
-func enumerateFormats() []Format { return nil }
+// enumerateFormats reports the formats currently on the clipboard. The X11 path
+// is implemented here; the Wayland path lands in a follow-up PR (returns nil for
+// now).
+func enumerateFormats() []Format {
+	if useWayland {
+		return nil
+	}
+	return x11EnumerateFormats()
+}
 
 func read(t Format) (buf []byte, err error) {
 	if useWayland {

--- a/clipboard_x11.go
+++ b/clipboard_x11.go
@@ -15,11 +15,13 @@ package clipboard
 
 import (
 	"bufio"
+	"encoding/binary"
 	"net"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	x11wire "golang.design/x/x11"
@@ -304,6 +306,108 @@ func x11Read(target string) ([]byte, error) {
 		return nil, nil
 	}
 	return v, nil
+}
+
+// atomName resolves an atom id to its string name via GetAtomName.
+func (x *x11conn) atomName(atom uint32) (string, error) {
+	seq, err := x.send(x11wire.GetAtomName(atom))
+	if err != nil {
+		return "", err
+	}
+	p, err := x.reply(seq)
+	if err != nil {
+		return "", err
+	}
+	return p.AtomName(), nil
+}
+
+// x11Targets returns the target names the current CLIPBOARD selection advertises
+// (via the TARGETS target), or nil if the clipboard is empty. The TARGETS
+// property is a list of 4-byte atom ids, each resolved back to its name.
+func x11Targets() ([]string, error) {
+	x, err := x11Connect()
+	if err != nil {
+		return nil, errUnavailable
+	}
+	defer x.Close()
+	x.c.SetReadDeadline(time.Now().Add(x11ReadTimeout))
+
+	sel, e1 := x.intern("CLIPBOARD")
+	prop, e2 := x.intern("GOLANG_DESIGN_DATA")
+	tgts, e3 := x.intern("TARGETS")
+	if e1 != nil || e2 != nil || e3 != nil {
+		return nil, errUnavailable
+	}
+
+	if _, err := x.send(x11wire.ConvertSelection(x.win, sel, tgts, prop, x11wire.CurrentTime)); err != nil {
+		return nil, errUnavailable
+	}
+	for {
+		p, err := x11wire.NextEvent(x.r)
+		if err != nil {
+			return nil, errUnavailable
+		}
+		if p.EventCode() != x11wire.EventSelectionNotify {
+			continue
+		}
+		if p.SelectionNotify().Property == x11wire.None {
+			return nil, nil // empty clipboard
+		}
+		break
+	}
+
+	gseq, err := x.send(x11wire.GetProperty(true, x.win, prop, 0, 0, 0xffffffff))
+	if err != nil {
+		return nil, errUnavailable
+	}
+	rp, err := x.reply(gseq)
+	if err != nil {
+		return nil, errUnavailable
+	}
+
+	atoms := rp.PropertyValue() // ATOM list, 4 bytes each
+	names := make([]string, 0, len(atoms)/4)
+	for i := 0; i+4 <= len(atoms); i += 4 {
+		name, err := x.atomName(binary.LittleEndian.Uint32(atoms[i:]))
+		if err != nil || name == "" {
+			continue
+		}
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+// x11EnumerateFormats maps the advertised TARGETS to Format tokens, registering
+// custom MIME types on demand. Shared by the Linux and BSD backends.
+func x11EnumerateFormats() []Format {
+	names, err := x11Targets()
+	if err != nil {
+		return nil
+	}
+	out := make([]Format, 0, len(names))
+	for _, n := range names {
+		if f, ok := x11FormatForTarget(n); ok {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// x11FormatForTarget maps an X11 target/atom name to a Format: the common text
+// atoms to FmtText, image/png to FmtImage, any other MIME-shaped name (one that
+// contains '/') to a registered custom format. X11 meta-targets such as TARGETS,
+// MULTIPLE and TIMESTAMP have no '/', so they are ignored.
+func x11FormatForTarget(name string) (Format, bool) {
+	switch name {
+	case "UTF8_STRING", "STRING", "TEXT", "text/plain", "text/plain;charset=utf-8":
+		return FmtText, true
+	case "image/png":
+		return FmtImage, true
+	}
+	if strings.Contains(name, "/") {
+		return Register(name), true
+	}
+	return 0, false
 }
 
 // x11Write takes ownership of the CLIPBOARD selection and serves its content to

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 require (
 	github.com/ebitengine/purego v0.10.1
-	golang.design/x/x11 v0.1.0
+	golang.design/x/x11 v0.2.0
 	golang.org/x/image v0.28.0
 	golang.org/x/mobile v0.0.0-20250606033058-a2a15c67f36f
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/ebitengine/purego v0.10.1 h1:dewVBCBT2GaMu1SrNTYxQhgQBethzfhiwvZiLGP/
 github.com/ebitengine/purego v0.10.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 golang.design/x/x11 v0.1.0 h1:zkukar6i5eOz/IUZ9QXOglaU40hl/czWGpWP4brZCM0=
 golang.design/x/x11 v0.1.0/go.mod h1:/5q1mFkdc1rL8mvB7DsQFi6as4tIkBv4FXjcP07mrkE=
+golang.design/x/x11 v0.2.0 h1:Uiwu2guGihsJX/ZCzpoDPFz5gR/Qntm08mvoBCmRydo=
+golang.design/x/x11 v0.2.0/go.mod h1:/5q1mFkdc1rL8mvB7DsQFi6as4tIkBv4FXjcP07mrkE=
 golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476 h1:Wdx0vgH5Wgsw+lF//LJKmWOJBLWX6nprsMqnf99rYDE=
 golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476/go.mod h1:ygj7T6vSGhhm/9yTpOQQNvuAUFziTH7RUiH74EoE2C8=
 golang.org/x/image v0.28.0 h1:gdem5JW1OLS4FbkWgLO+7ZeFzYtL3xClb97GaUzYMFE=


### PR DESCRIPTION
Backend PR of the format-enumeration rollout ([spec](../blob/main/specs/clipboard-format-enumeration.md)). Builds on #137. Refs #89.

## Scope (X11 backend — Linux + BSD)

- Enumerate the CLIPBOARD selection's advertised `TARGETS` and map each to a `Format`: text atoms → `FmtText`, `image/png` → `FmtImage`, other MIME-shaped names (containing `/`) → a custom format registered on demand. X11 meta-targets (`TARGETS`, `MULTIPLE`, `TIMESTAMP`, …) are ignored.
- `TARGETS` is a list of atom **ids**; resolved to names via the new `GetAtomName`/`Packet.AtomName` in **`golang.design/x/x11` v0.2.0** (bumped here; released from golang-design/x11#1).
- `x11Targets`/`x11EnumerateFormats` live in the shared X11 backend; Linux (non-Wayland) and the BSDs wire `enumerateFormats` to it. Wayland enumeration is a follow-up (returns nil for now; the Linux test skips under `WAYLAND_DISPLAY`).

## Tests

Shared `enumerateRoundTrip` helper + a Linux `TestFormatsEnumerate` (runs on the X11 ubuntu job): writes a built-in and a custom `text/html`, asserts `Formats()` reports them with the right `Format.MIME()`. BSD CI is build-only.

Verified locally via cross-compile + test-compile for linux/freebsd/openbsd; darwin suite unaffected.