### PR TITLE
wayland: implement Formats() enumeration on the data-control backend (#89)

### DIFF
--- a/clipboard_enumerate_linux_test.go
+++ b/clipboard_enumerate_linux_test.go
@@ -13,11 +13,13 @@ import (
 	"testing"
 )
 
+// TestFormatsEnumerate exercises same-process enumeration on the X11 backend.
+// The Wayland data-control backend is covered cross-process by
+// clipboard_enumerate_wayland_test.go: a process does not observe its own
+// just-set custom selection there (same caveat as the custom-format tests).
 func TestFormatsEnumerate(t *testing.T) {
-	// This PR implements enumeration on the X11 backend. Wayland enumeration
-	// lands in a follow-up PR; skip there for now.
 	if os.Getenv("WAYLAND_DISPLAY") != "" {
-		t.Skip("Wayland enumeration lands in a separate PR")
+		t.Skip("Wayland enumeration is covered cross-process")
 	}
 	enumerateRoundTrip(t)
 }

--- a/clipboard_enumerate_wayland_test.go
+++ b/clipboard_enumerate_wayland_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+//go:build linux && !android
+
+package clipboard
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestWaylandFormatsEnumerate verifies data-control enumeration: an independent
+// client (wl-copy --type) sets a custom MIME type, and the backend reports it
+// (mapped to a registered Format) from the current selection's offer. Runs under
+// headless sway; skips off-Wayland or without wl-clipboard.
+func TestWaylandFormatsEnumerate(t *testing.T) {
+	if os.Getenv("WAYLAND_DISPLAY") == "" {
+		t.Skip("not a Wayland session (WAYLAND_DISPLAY unset)")
+	}
+	if _, err := exec.LookPath("wl-copy"); err != nil {
+		t.Skip("wl-copy not found")
+	}
+
+	const mime = "application/x.golang-design.enumerate"
+	cmd := exec.Command("wl-copy", "--type", mime)
+	cmd.Stdin = bytes.NewReader([]byte("enumerate"))
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("wl-copy: %v", err)
+	}
+	time.Sleep(200 * time.Millisecond) // let wl-copy acquire selection ownership
+
+	want := Register(mime)
+	fs := enumerateFormats()
+	found := false
+	for _, f := range fs {
+		if f == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("enumerateFormats() = %v, want it to include the %s token %v", fs, mime, want)
+	}
+}

--- a/clipboard_enumerate_wayland_test.go
+++ b/clipboard_enumerate_wayland_test.go
@@ -37,7 +37,10 @@ func TestWaylandFormatsEnumerate(t *testing.T) {
 	time.Sleep(200 * time.Millisecond) // let wl-copy acquire selection ownership
 
 	want := Register(mime)
-	fs := enumerateFormats()
+	// Call the Wayland enumeration directly (like the other wl* tests): the
+	// public enumerateFormats() routes on useWayland, which is only set by
+	// Init() and unset in this unit test.
+	fs := wlEnumerateFormats()
 	found := false
 	for _, f := range fs {
 		if f == want {

--- a/clipboard_linux.go
+++ b/clipboard_linux.go
@@ -52,12 +52,11 @@ func initialize() error {
 	return nil
 }
 
-// enumerateFormats reports the formats currently on the clipboard. The X11 path
-// is implemented here; the Wayland path lands in a follow-up PR (returns nil for
-// now).
+// enumerateFormats reports the formats currently on the clipboard, via the
+// Wayland data-control offer or the X11 TARGETS list.
 func enumerateFormats() []Format {
 	if useWayland {
-		return nil
+		return wlEnumerateFormats()
 	}
 	return x11EnumerateFormats()
 }

--- a/clipboard_wayland_linux.go
+++ b/clipboard_wayland_linux.go
@@ -427,6 +427,83 @@ func wlReadSelection(mimes []string) ([]byte, error) {
 	return data, nil
 }
 
+// wlSelectionMIMEs returns the MIME types advertised by the current clipboard
+// selection, or nil if the clipboard is empty. It mirrors wlReadSelection's
+// offer-collection but returns the type list instead of receiving data.
+func wlSelectionMIMEs() ([]string, error) {
+	w, _, deviceID, err := wlConnectDevice()
+	if err != nil {
+		return nil, err
+	}
+	defer w.Close()
+
+	sync2, err := w.sync()
+	if err != nil {
+		return nil, err
+	}
+
+	offers := make(map[uint32][]string)
+	var selection uint32
+	for {
+		obj, op, body, err := w.readEvent()
+		if err != nil {
+			return nil, err
+		}
+		switch {
+		case obj == wlDisplayID && op == 0:
+			return nil, wlDisplayError(body)
+		case obj == deviceID && op == devEvtDataOffer && len(body) >= 4:
+			offers[binary.LittleEndian.Uint32(body[0:])] = nil
+		case obj == deviceID && op == devEvtSelection && len(body) >= 4:
+			selection = binary.LittleEndian.Uint32(body[0:])
+		case op == offerEvtOffer:
+			if _, isOffer := offers[obj]; isOffer {
+				if mime, _, err := wlString(body, 0); err == nil {
+					offers[obj] = append(offers[obj], mime)
+				}
+			}
+		}
+		if obj == sync2 && op == 0 {
+			break
+		}
+	}
+	if selection == 0 {
+		return nil, nil
+	}
+	return offers[selection], nil
+}
+
+// wlEnumerateFormats maps the MIME types of the current selection to Format
+// tokens, registering custom types on demand.
+func wlEnumerateFormats() []Format {
+	mimes, err := wlSelectionMIMEs()
+	if err != nil {
+		return nil
+	}
+	out := make([]Format, 0, len(mimes))
+	for _, m := range mimes {
+		out = append(out, wlFormatForMIME(m))
+	}
+	return out
+}
+
+// wlFormatForMIME maps a Wayland MIME type to a Format: any of the known text
+// types to FmtText, image/png to FmtImage, and anything else to a custom format
+// registered on demand.
+func wlFormatForMIME(m string) Format {
+	for _, tm := range textMIMEs {
+		if m == tm {
+			return FmtText
+		}
+	}
+	for _, im := range imageMIMEs {
+		if m == im {
+			return FmtImage
+		}
+	}
+	return Register(m)
+}
+
 // wlReceiveOffer requests data for mime from the given offer and reads it from
 // a pipe whose write end is handed to the compositor (SCM_RIGHTS).
 func wlReceiveOffer(w *wlConn, offerID uint32, mime string) ([]byte, error) {


### PR DESCRIPTION
Backend PR of the format-enumeration rollout ([spec](../blob/main/specs/clipboard-format-enumeration.md)). Builds on #137/#138. Refs #89.

## Scope (Wayland data-control backend)

- `wlEnumerateFormats` reads the current selection's advertised MIME list (`wlSelectionMIMEs`, mirroring `wlReadSelection`'s offer collection) and maps each type to a `Format`: known text types → `FmtText`, `image/png` → `FmtImage`, anything else → a custom format registered on demand.
- Linux wires the Wayland path of `enumerateFormats` to it.

## Tests

`TestWaylandFormatsEnumerate` (headless-sway `wayland_test` job): an independent `wl-copy --type` sets a custom MIME, and `enumerateFormats()` reports it as a registered token. Verified **cross-process** because — like the custom-format data path — a process doesn't observe its own just-set custom selection under data-control; the same-process X11 `TestFormatsEnumerate` skips on Wayland accordingly.