### PR TITLE
docs: document Formats()/Format.MIME(); mark enumeration spec Implemented (#89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,29 @@ Custom-format support is per platform:
   returns `nil` and `Write` is a no-op for custom formats — they degrade
   gracefully like the rest of the API.
 
+To discover what is currently on the clipboard, use `Formats`. It returns the
+available formats (registering any custom MIME types it finds on demand), and
+`Format.MIME` reports a token's identity:
+
+```go
+for _, f := range clipboard.Formats() {
+      switch f {
+      case clipboard.FmtText:
+            println("text")
+      case clipboard.FmtImage:
+            println("image")
+      default:
+            println("custom:", f.MIME()) // e.g. text/html, application/pdf
+            data := clipboard.Read(f)
+            _ = data
+      }
+}
+```
+
+`Formats` discovers types on the desktop backends (macOS, Windows, Linux/X11,
+BSD/X11, and Linux/Wayland); on iOS, Android, and CGO-disabled builds it returns
+an empty slice.
+
 ## Demos
 
 - A command line tool `gclip` for command line clipboard accesses, see document [here](./cmd/gclip/README.md).

--- a/clipboard.go
+++ b/clipboard.go
@@ -75,6 +75,11 @@ supported on the desktop backends (macOS, Windows, Linux/X11, BSD/X11, and
 Linux/Wayland for cross-application exchange); on iOS, Android, and
 CGO-disabled builds they degrade gracefully like the rest of the API.
 
+To discover what is currently on the clipboard, Formats reports the available
+formats (registering any custom MIME types it finds on demand), and
+Format.MIME reports a token's MIME identity. Enumeration works on the desktop
+backends and returns an empty slice on iOS, Android, and CGO-disabled builds.
+
 # Platform-specific caveats
 
 On Linux/X11 the clipboard follows the X11 selection-ownership model:

--- a/specs/clipboard-format-enumeration.md
+++ b/specs/clipboard-format-enumeration.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | Proposed |
+| **Status** | Implemented |
 | **Issue** | [#89](https://github.com/golang-design/clipboard/issues/89) (enumeration half) |
 | **Builds on** | custom formats ([#17](https://github.com/golang-design/clipboard/issues/17)), tagged `Watch` ([#124](https://github.com/golang-design/clipboard/pull/124)) |
 
@@ -121,3 +121,36 @@ Spec-first, then one PR per scope (mirroring the custom-format rollout):
 
 Each lands green on CI with a round-trip test that writes a known format and
 asserts `Formats()` reports it.
+
+## 8. Outcome
+
+Shipped as `Formats() []Format` and `Format.MIME() string` (Option B —
+discovery with on-demand registration), rolled out one PR per scope:
+
+| PR | Scope |
+|---|---|
+| golang-design/x11#1 (v0.2.0) | `GetAtomName` + `Packet.AtomName` in the x11 codec |
+| #137 | Core: `Formats`, `Format.MIME`, `normalizeFormats`, `enumerateFormats` seam |
+| #138 | Linux/X11 + BSD — `TARGETS` enumeration (bumps x11 to v0.2.0) |
+| #139 | Linux/Wayland — offered-MIME enumeration |
+| #140 | Windows — `EnumClipboardFormats` + `GetClipboardFormatName` |
+| #141 | macOS — `NSPasteboard types` + UTI mapping |
+| this PR | Docs + spec wrap-up |
+
+### Design evolution (discovered during implementation)
+
+- **X11 needed a codec change.** `TARGETS` yields atom *ids*; reversing them to
+  names required `GetAtomName`, absent from `golang.design/x/x11` v0.1.0 (and
+  `Packet` exposed no raw bytes to hand-roll it). Added `GetAtomName` +
+  `Packet.AtomName` and released v0.2.0 — the full-parity path chosen over a
+  curated-candidate compromise.
+- **Wayland self-read caveat carries over.** Same as the custom-format data
+  path, a process does not observe its own just-set custom selection under
+  data-control, so Wayland enumeration is verified cross-process (`wl-copy`);
+  the same-process test skips on Wayland.
+- **Tests call backend internals on Wayland.** `enumerateFormats()` routes on
+  `useWayland` (set only by `Init`), so the Wayland test calls
+  `wlEnumerateFormats()` directly, matching the other `wl*` tests.
+
+This completes the enumeration half of #89; the tagged `Watch` (the "return a
+type with the content" half) shipped earlier in #124.


### PR DESCRIPTION
Final PR of the format-enumeration rollout ([spec](../blob/main/specs/clipboard-format-enumeration.md)). Closes the #89 enumeration work.

- **README + package godoc:** how to discover clipboard contents with `Formats()` and inspect a token via `Format.MIME()`, with the per-platform note (desktop backends discover; iOS/Android/CGO-disabled return empty).
- **Spec:** Status → **Implemented**, plus an Outcome section mapping each scope to its PR (incl. the `golang.design/x/x11` v0.2.0 `GetAtomName` release) and the design evolutions found during implementation (X11 codec change, Wayland self-read caveat, test calling backend internals).

Docs-only. With this, both halves of #89 are done: the tagged `Watch` (#124) and enumeration (`Formats()`/`Format.MIME()`).