### PR TITLE
go.mod: tidy stale x/x11 v0.1.0 checksum from go.sum

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/ebitengine/purego v0.10.1 h1:dewVBCBT2GaMu1SrNTYxQhgQBethzfhiwvZiLGP/qyY=
 github.com/ebitengine/purego v0.10.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
-golang.design/x/x11 v0.1.0 h1:zkukar6i5eOz/IUZ9QXOglaU40hl/czWGpWP4brZCM0=
-golang.design/x/x11 v0.1.0/go.mod h1:/5q1mFkdc1rL8mvB7DsQFi6as4tIkBv4FXjcP07mrkE=
 golang.design/x/x11 v0.2.0 h1:Uiwu2guGihsJX/ZCzpoDPFz5gR/Qntm08mvoBCmRydo=
 golang.design/x/x11 v0.2.0/go.mod h1:/5q1mFkdc1rL8mvB7DsQFi6as4tIkBv4FXjcP07mrkE=
 golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476 h1:Wdx0vgH5Wgsw+lF//LJKmWOJBLWX6nprsMqnf99rYDE=


### PR DESCRIPTION
Pre-release hygiene: `go mod tidy` drops the superseded `golang.design/x/x11 v0.1.0` hashes left in go.sum by the v0.2.0 bump (#138). No code change.