### PR TITLE
specs: mark darwin/linux/wayland Implemented with Outcome + deviations (#149)

### DIFF
--- a/specs/darwin-remove-cgo.md
+++ b/specs/darwin-remove-cgo.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | Proposed |
+| **Status** | Implemented |
 | **Issue** | [#69](https://github.com/golang-design/clipboard/issues/69) |
 | **Supersedes** | [#51](https://github.com/golang-design/clipboard/issues/51) (folded into #69) |
 | **Builds on** | [#83](https://github.com/golang-design/clipboard/pull/83) (TotallyGamerJet — purego prototype) |
@@ -232,3 +232,35 @@ CI already does the heavy lifting — `.github/workflows/clipboard.yml` runs, on
 - **Upside:** darwin joins Windows as a Cgo-free desktop backend; cross-compiling
   to macOS from a toolchain-less environment becomes possible; momentum for the
   parallel Linux goal (#25).
+
+## 12. Outcome
+
+Shipped in **#117** (purego/objc `NSPasteboard` binding), with follow-on
+hardening commits for autorelease handling, the TIFF fallback, and test scope.
+
+**As designed:**
+- purego `objc` over `dlopen`/`dlsym` to `NSPasteboard`; no C compiler at build
+  time and `clipboard_darwin.m` deleted.
+- TIFF read fallback via **Option B** (raw TIFF bytes → pure-Go transcode with
+  `x/image/tiff` + `image/png`).
+- `clipboard_nocgo.go` build tag flipped to exclude darwin; `purego` pinned to
+  `v0.10.1`; `runtime.KeepAlive` around every buffer handed to Obj-C.
+
+**Deviations from the design:**
+- **OS-thread pinning was required, unanticipated.** Draining an autorelease
+  pool after a goroutine migrated threads crashes; `newAutoreleasePool` pins the
+  OS thread (`runtime.LockOSThread`/`UnlockOSThread`) for the pool's lifetime —
+  a correctness detail §7 did not foresee.
+- **The suggested pure-Go TIFF transcode unit test (§8) was not added.** The
+  TIFF test still drives a real pasteboard via `sips`/`osascript` (it only
+  dropped its `CGO_ENABLED=0` skip).
+- **Wider test un-skip than §8 enumerated** (also un-skipped `TestClipboard`,
+  `…MultipleWrites`, `…ConcurrentRead`, `…WriteEmpty`, `…Watch` under
+  `CGO_ENABLED=0`) — strictly more coverage.
+
+**Known limitation:** a failed TIFF transcode in `clipboard_read_image` returns
+`nil` silently with no Option-A recovery — the §6 "exotic TIFF variant" residual
+risk is live.
+
+Custom pasteboard-type formats and `Formats()` enumeration were added later
+(#129/#137/#141), outside this spec's scope.

--- a/specs/linux-remove-cgo.md
+++ b/specs/linux-remove-cgo.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | Proposed |
+| **Status** | Implemented |
 | **Issue** | [#25](https://github.com/golang-design/clipboard/issues/25) |
 | **Related** | [#69](https://github.com/golang-design/clipboard/issues/69)/[#117](https://github.com/golang-design/clipboard/pull/117) (darwin, done), [`specs/wayland-support.md`](./wayland-support.md) (the pure-Go precedent), [#55](https://github.com/golang-design/clipboard/issues/55) (BSD) |
 | **Builds on** | [#20](https://github.com/golang-design/clipboard/pull/20) (runtime `dlopen` of libX11) |
@@ -263,3 +263,40 @@ rule).
   cross-compiling to Linux needs no C toolchain; under Option A the `libX11`
   runtime dependency disappears entirely; and the existing Wayland backend
   becomes usable in cgo-free builds.
+
+## 12. Outcome
+
+Shipped as **Option A** across **#119** (the pure-Go X11 wire codec) and
+**#120** (the Linux backend), with **#121** extending the same backend to the
+BSDs.
+
+**As designed:**
+- Pure-Go X11 wire protocol over the display socket — no `libX11` at runtime, no
+  C toolchain at build. `$DISPLAY` parsing, MIT-MAGIC-COOKIE-1 auth from
+  `~/.Xauthority`, and the full selection protocol (InternAtom, CreateWindow,
+  Set/GetSelectionOwner, ConvertSelection, ChangeProperty/GetProperty, SendEvent).
+- The #61 crash guard dissolves structurally: the read loop owns error packets
+  (`NextEvent` drops X11 errors), so no Xlib default handler is needed; the old
+  error-handler test was removed.
+- `clipboard_nocgo.go` build tag updated to exclude Linux/BSD; CGO=0 round-trip
+  tests un-skipped in CI.
+- **INCR / PRIMARY remain unimplemented**, matching the old C behavior (no
+  regression) — still follow-ups (#67/#22).
+
+**Deviations from the design:**
+- **The codec became its own module.** The spec proposed an in-repo
+  `internal/x11wire`; it shipped that way in #119 but was then **extracted to a
+  first-party module `golang.design/x/x11`** (#122), which clipboard now depends
+  on (go.mod: `v0.2.0` — bumped from v0.1.0 when `GetAtomName` was added for
+  `Formats()` enumeration, #138). In `clipboard_x11.go` it is imported aliased as
+  `x11wire`.
+- **One shared file for all X11 platforms.** Rather than the proposed
+  `clipboard_x11_linux.go` (`linux && !android`), the backend is
+  `clipboard_x11.go` with `(linux || freebsd || openbsd || netbsd) && !android`,
+  because BSD support (#121) landed immediately after.
+- **Added robustness not in the design:** per-reply sequence-number matching,
+  CreateWindow confirmation with retry on `BadIDChoice`, and connection-setup
+  retries to tolerate transient resets under churn.
+
+Custom formats and `Formats()` enumeration on X11 were added later
+(#130/#138), reusing this backend.

--- a/specs/wayland-support.md
+++ b/specs/wayland-support.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | Proposed |
+| **Status** | Implemented |
 | **Issue** | [#6](https://github.com/golang-design/clipboard/issues/6) |
 | **Also closes** | [#61](https://github.com/golang-design/clipboard/issues/61) (crash on Wayland, folded into #6) |
 | **Related** | [#67](https://github.com/golang-design/clipboard/issues/67) (primary selection), [#25](https://github.com/golang-design/clipboard/issues/25)/[#51](https://github.com/golang-design/clipboard/issues/51) (drop Cgo) |
@@ -183,3 +183,35 @@ CI attempt, where an untested job was worse than none).
   event-driven `Watch`, and primary-selection support (#67) on Wayland.
 - **Risk:** headless-compositor CI flakiness; mitigated by treating CI setup as
   part of phase 2 rather than an afterthought.
+
+## 12. Outcome
+
+Shipped across **#109–#116** as a phased rollout (graceful-fail #110, wire core
+#112, read #113, write #114, watch #115, dispatch #116), tested under headless
+sway in CI against independent `wl-copy`/`wl-paste` clients.
+
+**As designed:**
+- Native data-control backend supporting `ext_data_control_manager_v1`
+  (preferred) and `zwlr_data_control_manager_v1` (fallback); fd passing via
+  `SCM_RIGHTS`.
+- Backend selection in `initialize()` probes `WAYLAND_DISPLAY` **and** verifies a
+  data-control manager is actually advertised (`wlAvailable`), falling back to
+  X11/XWayland otherwise.
+- `Watch` is **event-driven** (selection events, no polling), with a baseline
+  capture matching the X11 contract.
+
+**Deviations / limitations:**
+- **Phase 6 (wlr fallback) folded into the wire core** rather than shipping as a
+  separate phase; both managers are handled in #112.
+- **Primary selection not shipped.** §6/§11 floated it as an upside, but the
+  implementation covers only the regular CLIPBOARD selection; PRIMARY remains
+  reserved (#67).
+- **Same-process self-read limitation (discovered later).** Under data-control a
+  process does **not** observe its own just-set *custom* selection from a fresh
+  reader connection (built-in text/image happen to work same-process). Found
+  while adding custom formats; the same-process tests skip on Wayland and
+  cross-process interop is verified with `wl-copy`/`wl-paste` instead
+  (`clipboard_custom_linux_test.go`, #131).
+- **Custom formats + `Formats()` enumeration added later** (#131/#139), outside
+  the original phases — `wlEnumerateFormats` maps offered MIME types to Format
+  tokens, registering custom types on demand.


### PR DESCRIPTION
Closes #149. The darwin/linux/wayland specs still read **Proposed** despite shipping. Flip each to **Implemented** and add an **Outcome** section documenting what shipped and the design deviations found during implementation (researched from the merged code + git history):

- **darwin** (#117): OS-thread pinning for autorelease pools (unanticipated by the design); the suggested pure-Go TIFF unit test was not added; failed TIFF transcode returns nil silently.
- **linux** (#119/#120, BSD #121): `internal/x11wire` was **extracted to the `golang.design/x/x11` module** (#122, now v0.2.0); one shared `clipboard_x11.go` covers Linux+BSD; added sequence-matching/retry robustness; INCR/PRIMARY still unimplemented (as scoped).
- **wayland** (#109–#116): phase 6 folded into the wire core; PRIMARY not shipped; the same-process self-read limitation for custom selections (verified cross-process); enumeration added later.

Docs-only.