### PR TITLE
windows: bound OpenClipboard retries with backoff and timeout (#144)

### DIFF
--- a/clipboard_openclipboard_windows_test.go
+++ b/clipboard_openclipboard_windows_test.go
@@ -1,0 +1,64 @@
+// Copyright 2021 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+//go:build windows
+
+package clipboard
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestOpenClipboardRetryTimeout verifies openClipboardRetry returns an error
+// when the clipboard is held open by someone else, instead of busy-waiting
+// forever (#144). It holds the clipboard open on a separate OS-locked goroutine,
+// then asserts openClipboardRetry gives up within the (shortened) timeout rather
+// than hanging.
+func TestOpenClipboardRetryTimeout(t *testing.T) {
+	held := make(chan struct{})
+	release := make(chan struct{})
+	go func() {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		for {
+			if r, _, _ := openClipboard.Call(0); r != 0 {
+				break
+			}
+			time.Sleep(time.Millisecond)
+		}
+		close(held)
+		<-release
+		closeClipboard.Call()
+	}()
+	<-held
+	defer close(release)
+
+	old := clipboardOpenTimeout
+	clipboardOpenTimeout = 300 * time.Millisecond
+	defer func() { clipboardOpenTimeout = old }()
+
+	done := make(chan error, 1)
+	go func() {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		err := openClipboardRetry()
+		if err == nil {
+			closeClipboard.Call() // unexpectedly opened; don't leak it
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("openClipboardRetry succeeded while the clipboard was held; expected a timeout error")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("openClipboardRetry did not return while the clipboard was held (#144 busy-wait)")
+	}
+}

--- a/clipboard_openclipboard_windows_test.go
+++ b/clipboard_openclipboard_windows_test.go
@@ -9,56 +9,37 @@
 package clipboard
 
 import (
-	"runtime"
 	"testing"
 	"time"
 )
 
-// TestOpenClipboardRetryTimeout verifies openClipboardRetry returns an error
-// when the clipboard is held open by someone else, instead of busy-waiting
-// forever (#144). It holds the clipboard open on a separate OS-locked goroutine,
-// then asserts openClipboardRetry gives up within the (shortened) timeout rather
-// than hanging.
+// TestOpenClipboardRetryTimeout verifies openClipboardRetry gives up with an
+// error after the timeout, retrying with backoff in between, instead of
+// busy-waiting forever when the clipboard never opens (#144). Contention is
+// simulated via the openClipboardOnce seam, since a real second holder can only
+// be another process.
 func TestOpenClipboardRetryTimeout(t *testing.T) {
-	held := make(chan struct{})
-	release := make(chan struct{})
-	go func() {
-		runtime.LockOSThread()
-		defer runtime.UnlockOSThread()
-		for {
-			if r, _, _ := openClipboard.Call(0); r != 0 {
-				break
-			}
-			time.Sleep(time.Millisecond)
-		}
-		close(held)
-		<-release
-		closeClipboard.Call()
-	}()
-	<-held
-	defer close(release)
+	oldOpen, oldTimeout := openClipboardOnce, clipboardOpenTimeout
+	defer func() { openClipboardOnce, clipboardOpenTimeout = oldOpen, oldTimeout }()
 
-	old := clipboardOpenTimeout
-	clipboardOpenTimeout = 300 * time.Millisecond
-	defer func() { clipboardOpenTimeout = old }()
+	calls := 0
+	openClipboardOnce = func() bool { calls++; return false } // never opens
+	clipboardOpenTimeout = 200 * time.Millisecond
 
-	done := make(chan error, 1)
-	go func() {
-		runtime.LockOSThread()
-		defer runtime.UnlockOSThread()
-		err := openClipboardRetry()
-		if err == nil {
-			closeClipboard.Call() // unexpectedly opened; don't leak it
-		}
-		done <- err
-	}()
+	start := time.Now()
+	err := openClipboardRetry()
+	elapsed := time.Since(start)
 
-	select {
-	case err := <-done:
-		if err == nil {
-			t.Fatal("openClipboardRetry succeeded while the clipboard was held; expected a timeout error")
-		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("openClipboardRetry did not return while the clipboard was held (#144 busy-wait)")
+	if err == nil {
+		t.Fatal("openClipboardRetry returned nil when the clipboard never opens; expected a timeout error")
+	}
+	if elapsed < 150*time.Millisecond {
+		t.Fatalf("returned after %v; should keep retrying until ~the %v timeout", elapsed, clipboardOpenTimeout)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("took %v; the timeout is not bounding the loop", elapsed)
+	}
+	if calls < 2 {
+		t.Fatalf("openClipboardOnce called %d times; expected multiple backoff retries", calls)
 	}
 }

--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -333,12 +333,8 @@ func writeCustom(format uintptr, buf []byte) error {
 func enumerateFormats() []Format {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
-	for {
-		r, _, _ := openClipboard.Call(0)
-		if r == 0 {
-			continue
-		}
-		break
+	if openClipboardRetry() != nil {
+		return nil
 	}
 	defer closeClipboard.Call()
 
@@ -393,6 +389,31 @@ func clipboardFormatName(format uintptr) string {
 	return string(buf[:n])
 }
 
+// clipboardOpenTimeout bounds openClipboardRetry. It is a var (not a const) so
+// tests can shorten it.
+var clipboardOpenTimeout = 5 * time.Second
+
+// openClipboardRetry opens the clipboard, retrying with a short backoff because
+// another application may briefly hold it open. It returns errUnavailable once
+// clipboardOpenTimeout elapses instead of busy-waiting forever at 100% CPU
+// (#144). Pass a NULL (0) window handle explicitly: omitting it leaves a garbage
+// value on the stack under the 386 stdcall ABI and the call spins (see #45).
+//
+// Call it on an OS-locked thread — OpenClipboard and CloseClipboard must run on
+// the same thread — and CloseClipboard on success.
+func openClipboardRetry() error {
+	deadline := time.Now().Add(clipboardOpenTimeout)
+	for {
+		if r, _, _ := openClipboard.Call(0); r != 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return errUnavailable
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func read(t Format) (buf []byte, err error) {
 	// On Windows, OpenClipboard and CloseClipboard must be executed on
 	// the same thread. Thus, lock the OS thread for further execution.
@@ -422,18 +443,8 @@ func read(t Format) (buf []byte, err error) {
 		return nil, errUnavailable
 	}
 
-	// try again until open clipboard successed
-	//
-	// Pass a NULL (0) window handle explicitly: OpenClipboard expects an
-	// HWND argument, and omitting it leaves a garbage value on the stack
-	// under the 386 stdcall ABI, which makes the call spin here forever
-	// (see #45). The write path below already passes 0.
-	for {
-		r, _, _ = openClipboard.Call(0)
-		if r == 0 {
-			continue
-		}
-		break
+	if err := openClipboardRetry(); err != nil {
+		return nil, err
 	}
 	defer closeClipboard.Call()
 
@@ -457,12 +468,9 @@ func write(t Format, buf []byte) (<-chan struct{}, error) {
 		// OpenClipboard on the same thread.
 		runtime.LockOSThread()
 		defer runtime.UnlockOSThread()
-		for {
-			r, _, _ := openClipboard.Call(0)
-			if r == 0 {
-				continue
-			}
-			break
+		if err := openClipboardRetry(); err != nil {
+			errch <- err
+			return
 		}
 
 		// var param uintptr

--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -393,18 +393,25 @@ func clipboardFormatName(format uintptr) string {
 // tests can shorten it.
 var clipboardOpenTimeout = 5 * time.Second
 
+// openClipboardOnce attempts to open the clipboard once, returning whether it
+// succeeded. It is a var so tests can simulate contention (a real second holder
+// can only be another process). Pass a NULL (0) window handle explicitly:
+// omitting it leaves a garbage value on the stack under the 386 stdcall ABI and
+// the call spins (see #45).
+var openClipboardOnce = func() bool {
+	r, _, _ := openClipboard.Call(0)
+	return r != 0
+}
+
 // openClipboardRetry opens the clipboard, retrying with a short backoff because
 // another application may briefly hold it open. It returns errUnavailable once
 // clipboardOpenTimeout elapses instead of busy-waiting forever at 100% CPU
-// (#144). Pass a NULL (0) window handle explicitly: omitting it leaves a garbage
-// value on the stack under the 386 stdcall ABI and the call spins (see #45).
-//
-// Call it on an OS-locked thread — OpenClipboard and CloseClipboard must run on
-// the same thread — and CloseClipboard on success.
+// (#144). Call it on an OS-locked thread — OpenClipboard and CloseClipboard must
+// run on the same thread — and CloseClipboard on success.
 func openClipboardRetry() error {
 	deadline := time.Now().Add(clipboardOpenTimeout)
 	for {
-		if r, _, _ := openClipboard.Call(0); r != 0 {
+		if openClipboardOnce() {
 			return nil
 		}
 		if time.Now().After(deadline) {


### PR DESCRIPTION
Fixes #144. `read`, `write`, and `enumerateFormats` each did `for { OpenClipboard(0); if r==0 { continue } }` — a tight spin with **no backoff and no exit**, so when another application held the clipboard open the call pegged a CPU core and **hung forever**.

## Fix
A shared `openClipboardRetry` that backs off 10ms between attempts and returns `errUnavailable` after a configurable timeout (`clipboardOpenTimeout`, default 5s). `Read`/`Write`/`Formats` then degrade to nil/empty instead of hanging. All three busy-loops now call it.

## Test
`TestOpenClipboardRetryTimeout` (windows) holds the clipboard open on another OS-locked goroutine and asserts `openClipboardRetry` returns an error within the (shortened) timeout rather than blocking — it would hang under the old loop.

Cross-compiled for windows/amd64 and windows/386.