### PR TITLE
clipboard: accept non-PNG image input, normalize to PNG (#155)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,13 @@ clipboard.Write(clipboard.FmtImage, []byte("image data"))
 clipboard.Read(clipboard.FmtImage)
 ```
 
-Note that read/write regarding image format assumes that the bytes are
-PNG encoded since it serves the alpha blending purpose that might be
-used in other graphical software.
+Note that the clipboard serves images as PNG (it serves the alpha-blending
+purpose used by other graphical software), so `Read(FmtImage)` always returns
+PNG. `Write(FmtImage, ...)` accepts PNG directly and will also normalize other
+encodings to PNG when their decoder is registered — blank-import the decoder you
+need (e.g. `import _ "image/jpeg"` or `import _ "golang.org/x/image/webp"`); no
+decoder is a mandatory dependency of this package. If you need to put raw,
+unconverted bytes on the clipboard, register a custom format instead (see above).
 
 In addition, `clipboard.Write` returns a channel that can receive an
 empty struct as a signal, which indicates the corresponding write call

--- a/clipboard.go
+++ b/clipboard.go
@@ -101,9 +101,12 @@ XWayland bridge with DISPLAY set.
 package clipboard // import "golang.design/x/clipboard"
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"image"
+	"image/png"
 	"os"
 	"sync"
 )
@@ -184,12 +187,19 @@ func Read(t Format) []byte {
 // If nothing else ever overwrites the clipboard, the channel never fires —
 // so do not block on it expecting it to report that this write completed.
 //
-// If format t indicates an image, then the given buf assumes
-// the image data is PNG encoded.
+// If format t indicates an image, buf is normalized to PNG before being placed
+// on the clipboard. PNG input is stored as-is; other formats are accepted if the
+// program has registered the matching image decoder (e.g. blank-import
+// _ "image/jpeg" or _ "golang.org/x/image/webp"), and undecodable input passes
+// through unchanged. The clipboard therefore always serves PNG, regardless of
+// the input encoding.
 func Write(t Format, buf []byte) <-chan struct{} {
 	lock.Lock()
 	defer lock.Unlock()
 
+	if t == FmtImage {
+		buf = toPNG(buf)
+	}
 	changed, err := write(t, buf)
 	if err != nil {
 		if debug {
@@ -198,6 +208,32 @@ func Write(t Format, buf []byte) <-chan struct{} {
 		return nil
 	}
 	return changed
+}
+
+// toPNG normalizes an FmtImage payload to canonical PNG: the clipboard stores
+// and serves PNG so consumers get a consistent, alpha-aware encoding. If buf is
+// already PNG (or not a decodable image) it is returned unchanged; otherwise it
+// is decoded and re-encoded as PNG.
+//
+// Decoding relies on the image decoders the importing program has registered, so
+// no decoder is a mandatory dependency of this package: to accept JPEG/GIF/WebP
+// input, blank-import the corresponding decoder (e.g. _ "image/jpeg",
+// _ "golang.org/x/image/webp"). Unknown or undecodable input passes through
+// unchanged, preserving the previous bytes-in behavior.
+func toPNG(buf []byte) []byte {
+	// Cheap path: already PNG (avoid a needless decode/encode round-trip).
+	if len(buf) >= 8 && bytes.Equal(buf[:8], []byte("\x89PNG\r\n\x1a\n")) {
+		return buf
+	}
+	img, _, err := image.Decode(bytes.NewReader(buf))
+	if err != nil {
+		return buf // not a decodable image (or its decoder isn't registered)
+	}
+	var out bytes.Buffer
+	if err := png.Encode(&out, img); err != nil {
+		return buf
+	}
+	return out.Bytes()
 }
 
 // Data is a single observed clipboard change: the format the change was

--- a/clipboard_imageinput_test.go
+++ b/clipboard_imageinput_test.go
@@ -14,6 +14,7 @@ import (
 	"image/png"
 	"os"
 	"testing"
+	"time"
 
 	"golang.design/x/clipboard"
 )
@@ -42,7 +43,15 @@ func TestWriteImageAcceptsJPEG(t *testing.T) {
 
 	clipboard.Write(clipboard.FmtImage, jbuf.Bytes())
 
-	got := clipboard.Read(clipboard.FmtImage)
+	// Poll Read: on some backends (Wayland data-control) a freshly set
+	// selection takes a moment to be visible to a new reader connection.
+	var got []byte
+	for i := 0; i < 50; i++ {
+		if got = clipboard.Read(clipboard.FmtImage); got != nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 	if got == nil {
 		t.Fatal("Read(FmtImage) returned nil after writing a JPEG")
 	}

--- a/clipboard_imageinput_test.go
+++ b/clipboard_imageinput_test.go
@@ -1,0 +1,59 @@
+// Copyright 2021 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+package clipboard_test
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg" // also registers the JPEG decoder used by Write's normalization
+	"image/png"
+	"os"
+	"testing"
+
+	"golang.design/x/clipboard"
+)
+
+// TestWriteImageAcceptsJPEG verifies Write(FmtImage, ...) accepts a non-PNG
+// image (JPEG here) when its decoder is registered, normalizes it to PNG, and
+// serves PNG back (#155). Without normalization the raw JPEG bytes would be
+// stored under the image format and Read would return non-PNG data.
+func TestWriteImageAcceptsJPEG(t *testing.T) {
+	if degradesWithoutCgo() {
+		if val, ok := os.LookupEnv("CGO_ENABLED"); ok && val == "0" {
+			t.Skip("CGO_ENABLED is set to 0")
+		}
+	}
+
+	src := image.NewRGBA(image.Rect(0, 0, 8, 8))
+	for y := 0; y < 8; y++ {
+		for x := 0; x < 8; x++ {
+			src.Set(x, y, color.RGBA{R: uint8(x * 32), G: uint8(y * 32), B: 64, A: 255})
+		}
+	}
+	var jbuf bytes.Buffer
+	if err := jpeg.Encode(&jbuf, src, nil); err != nil {
+		t.Fatalf("jpeg encode: %v", err)
+	}
+
+	clipboard.Write(clipboard.FmtImage, jbuf.Bytes())
+
+	got := clipboard.Read(clipboard.FmtImage)
+	if got == nil {
+		t.Fatal("Read(FmtImage) returned nil after writing a JPEG")
+	}
+	if !bytes.HasPrefix(got, []byte("\x89PNG\r\n\x1a\n")) {
+		t.Fatalf("clipboard image is not PNG-encoded (Write should normalize JPEG to PNG)")
+	}
+	img, err := png.Decode(bytes.NewReader(got))
+	if err != nil {
+		t.Fatalf("decode clipboard PNG: %v", err)
+	}
+	if b := img.Bounds(); b.Dx() != 8 || b.Dy() != 8 {
+		t.Fatalf("decoded image is %dx%d, want 8x8", b.Dx(), b.Dy())
+	}
+}

--- a/clipboard_imageinput_test.go
+++ b/clipboard_imageinput_test.go
@@ -29,6 +29,11 @@ func TestWriteImageAcceptsJPEG(t *testing.T) {
 			t.Skip("CGO_ENABLED is set to 0")
 		}
 	}
+	// Ensure the backend is initialized (selects Wayland vs X11); this test may
+	// run before TestClipboardInit, and Write/Read need the backend resolved.
+	if err := clipboard.Init(); err != nil {
+		t.Skipf("clipboard unavailable: %v", err)
+	}
 
 	src := image.NewRGBA(image.Rect(0, 0, 8, 8))
 	for y := 0; y < 8; y++ {


### PR DESCRIPTION
Closes #155. `Write(FmtImage, ...)` now normalizes input to canonical PNG via `image.Decode` + `png.Encode`, so callers can pass JPEG/GIF/WebP/… as long as they've registered the decoder.

- **No new mandatory deps:** decoding uses whatever decoders the program blank-imports (`_ "image/jpeg"`, `_ "golang.org/x/image/webp"`, …). The package itself only adds stdlib `image`/`image/png`.
- **No API change.** PNG input is detected by magic bytes and stored as-is (no needless re-encode); undecodable input passes through unchanged (previous behavior).
- **Output unchanged:** the clipboard still serves canonical PNG, honoring the alpha-blending rationale in the README. For raw, unconverted bytes, use a custom format (`Register`).
- Also improves discoverability of the PNG contract (#148).

`TestWriteImageAcceptsJPEG` writes a JPEG and asserts `Read(FmtImage)` returns PNG of the right dimensions — fails without the normalization. Verified locally on darwin; cross-compiled linux/windows/freebsd.