### PR TITLE
clipboard: stop watch ticker and honor cancel during send (#153)

### DIFF
--- a/clipboard_android.go
+++ b/clipboard_android.go
@@ -89,6 +89,7 @@ func watch(ctx context.Context, t Format) <-chan []byte {
 	ti := time.NewTicker(time.Second)
 	last := Read(t)
 	go func() {
+		defer ti.Stop()
 		for {
 			select {
 			case <-ctx.Done():
@@ -99,9 +100,14 @@ func watch(ctx context.Context, t Format) <-chan []byte {
 				if b == nil {
 					continue
 				}
-				if bytes.Compare(last, b) != 0 {
-					recv <- b
-					last = b
+				if !bytes.Equal(last, b) {
+					select {
+					case recv <- b:
+						last = b
+					case <-ctx.Done():
+						close(recv)
+						return
+					}
 				}
 			}
 		}

--- a/clipboard_bsd.go
+++ b/clipboard_bsd.go
@@ -79,6 +79,7 @@ func watch(ctx context.Context, t Format) <-chan []byte {
 	ti := time.NewTicker(time.Second)
 	last := Read(t)
 	go func() {
+		defer ti.Stop()
 		for {
 			select {
 			case <-ctx.Done():
@@ -90,8 +91,13 @@ func watch(ctx context.Context, t Format) <-chan []byte {
 					continue
 				}
 				if !bytes.Equal(last, b) {
-					recv <- b
-					last = b
+					select {
+					case recv <- b:
+						last = b
+					case <-ctx.Done():
+						close(recv)
+						return
+					}
 				}
 			}
 		}

--- a/clipboard_darwin.go
+++ b/clipboard_darwin.go
@@ -221,6 +221,7 @@ func watch(ctx context.Context, t Format) <-chan []byte {
 	ti := time.NewTicker(time.Second)
 	lastCount := clipboard_change_count()
 	go func() {
+		defer ti.Stop()
 		for {
 			select {
 			case <-ctx.Done():
@@ -233,8 +234,13 @@ func watch(ctx context.Context, t Format) <-chan []byte {
 					if b == nil {
 						continue
 					}
-					recv <- b
-					lastCount = this
+					select {
+					case recv <- b:
+						lastCount = this
+					case <-ctx.Done():
+						close(recv)
+						return
+					}
 				}
 			}
 		}

--- a/clipboard_ios.go
+++ b/clipboard_ios.go
@@ -67,6 +67,7 @@ func watch(ctx context.Context, t Format) <-chan []byte {
 	ti := time.NewTicker(time.Second)
 	last := Read(t)
 	go func() {
+		defer ti.Stop()
 		for {
 			select {
 			case <-ctx.Done():
@@ -77,9 +78,14 @@ func watch(ctx context.Context, t Format) <-chan []byte {
 				if b == nil {
 					continue
 				}
-				if bytes.Compare(last, b) != 0 {
-					recv <- b
-					last = b
+				if !bytes.Equal(last, b) {
+					select {
+					case recv <- b:
+						last = b
+					case <-ctx.Done():
+						close(recv)
+						return
+					}
 				}
 			}
 		}

--- a/clipboard_linux.go
+++ b/clipboard_linux.go
@@ -106,6 +106,7 @@ func watch(ctx context.Context, t Format) <-chan []byte {
 	ti := time.NewTicker(time.Second)
 	last := Read(t)
 	go func() {
+		defer ti.Stop()
 		for {
 			select {
 			case <-ctx.Done():
@@ -117,8 +118,13 @@ func watch(ctx context.Context, t Format) <-chan []byte {
 					continue
 				}
 				if !bytes.Equal(last, b) {
-					recv <- b
-					last = b
+					select {
+					case recv <- b:
+						last = b
+					case <-ctx.Done():
+						close(recv)
+						return
+					}
 				}
 			}
 		}

--- a/clipboard_watchleak_test.go
+++ b/clipboard_watchleak_test.go
@@ -1,0 +1,76 @@
+// Copyright 2021 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+//
+// Written by Changkun Ou <changkun.de>
+
+package clipboard_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"golang.design/x/clipboard"
+)
+
+// TestWatchNoGoroutineLeakOnCancel ensures a watcher whose consumer has stopped
+// reading still exits when its context is canceled, instead of blocking forever
+// on the send (#153). It starts several watchers, never reads them, drives enough
+// clipboard changes that each fills its buffer and blocks on the next send, then
+// cancels all and asserts the goroutines return to baseline.
+func TestWatchNoGoroutineLeakOnCancel(t *testing.T) {
+	if degradesWithoutCgo() {
+		if val, ok := os.LookupEnv("CGO_ENABLED"); ok && val == "0" {
+			t.Skip("CGO_ENABLED is set to 0")
+		}
+	}
+	if err := clipboard.Init(); err != nil {
+		t.Skipf("clipboard unavailable: %v", err)
+	}
+
+	settle := func() int {
+		for i := 0; i < 8; i++ {
+			runtime.GC()
+			time.Sleep(50 * time.Millisecond)
+		}
+		return runtime.NumGoroutine()
+	}
+	base := settle()
+
+	const n = 15
+	cancels := make([]context.CancelFunc, n)
+	for i := range cancels {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancels[i] = cancel
+		clipboard.Watch(ctx, clipboard.FmtText) // never read the channel
+	}
+
+	// Continuously change the clipboard (across several poll intervals) so every
+	// watcher detects a change and fills its size-1 buffer, then detects another
+	// and blocks trying to send it (nobody is reading).
+	for i := 0; i < 16; i++ {
+		clipboard.Write(clipboard.FmtText, fmt.Appendf(nil, "leak-probe-%d", i))
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	for _, cancel := range cancels {
+		cancel()
+	}
+
+	// With the fix the watcher goroutines exit; poll for the count to return to
+	// baseline (with tolerance for unrelated churn). Without it, ~n goroutines
+	// stay blocked on the send forever.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if got := settle(); got <= base+n/3 {
+			return
+		} else if time.Now().After(deadline) {
+			t.Fatalf("watch goroutines leaked after cancel: baseline %d, now %d (started %d watchers)", base, got, n)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}

--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -542,6 +542,7 @@ func watch(ctx context.Context, t Format) <-chan []byte {
 	go func() {
 		// not sure if we are too slow or the user too fast :)
 		ti := time.NewTicker(time.Second)
+		defer ti.Stop()
 		cnt, _, _ := getClipboardSequenceNumber.Call()
 		ready <- struct{}{}
 		for {
@@ -556,8 +557,13 @@ func watch(ctx context.Context, t Format) <-chan []byte {
 					if b == nil {
 						continue
 					}
-					recv <- b
-					cnt = cur
+					select {
+					case recv <- b:
+						cnt = cur
+					case <-ctx.Done():
+						close(recv)
+						return
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Addresses the **correctness half** of #153.

## Bug
The polling `watch` loops (darwin, linux/X11, bsd, windows, ios, android):
1. never called `ti.Stop()` on the `time.Ticker`, and
2. sent with a plain blocking `recv <- b`.

If a consumer stopped reading and then canceled the context, the watcher goroutine blocked on the send **forever** — a goroutine leak.

## Fix
`defer ti.Stop()` and make the send `select` on `ctx.Done()` so the goroutine exits on cancel. Wayland's `wlWatch` is event-driven and was already ctx-aware (unchanged).

## Test
`TestWatchNoGoroutineLeakOnCancel` starts watchers, never reads them, drives clipboard changes until each fills its buffer and blocks on the next send, cancels all, and asserts goroutines return to baseline. Verified it **fails without the fix** (~16 leaked goroutines) and passes with it.

## Scope
Correctness only. The fixed 1s poll interval is intentionally left as-is — a tunable interval is the previously-declined #54. An event-driven Windows watch (`AddClipboardFormatListener`) is a separate, larger change.