### PR TITLE
docs: pre-v0.8.0 pass — refresh README, fix stale image/format claims

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,13 @@
 # Test binary, built with `go test -c`
 *.test
 
+# Built demo command binaries (no extension)
+/gclip
+/gclip-gui
+/cmd/gclip/gclip
+/cmd/gclip-gui/gclip-gui
+/cmd/customformat/customformat
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@ import "golang.design/x/clipboard"
 ## Features
 
 - Cross platform supports: **macOS, Linux (X11 and Wayland), Windows, BSD (X11), iOS, and Android**
+- **Cgo-free on desktop** (macOS, Linux, Windows, BSD) — no C toolchain at build time, no `libX11`/`libwayland` at runtime
 - Copy/paste UTF-8 text
-- Copy/paste PNG encoded images (Desktop-only)
+- Copy/paste PNG-encoded images (Desktop-only); `Write` also accepts other encodings when their decoder is registered
 - Register and copy/paste custom MIME-typed formats (Desktop-only, raw passthrough)
+- Watch the clipboard for changes (event-driven on Wayland)
+- Discover what's on the clipboard with `Formats()` / `Format.MIME` (Desktop-only)
 - Command `gclip` as a demo application
 - Mobile app `gclip-gui` as a demo application
 
@@ -232,8 +235,10 @@ accessing system clipboards, but here are a few details you might need to know.
 - **Linux/X11 selection.** Only the `CLIPBOARD` selection (Ctrl+C/Ctrl+V)
   is accessed; the `PRIMARY` selection (middle-click paste) is not
   supported.
-- **Image format.** Image read/write assumes PNG-encoded data; other
-  encodings are undefined behavior.
+- **Image format.** `Read(FmtImage)` always returns PNG. `Write(FmtImage, ...)`
+  accepts PNG and normalizes other encodings to PNG when the matching decoder is
+  registered (blank-import it, e.g. `_ "image/jpeg"`). Use a custom format
+  (`Register`) for raw, unconverted bytes.
 - **Wayland.** The native Wayland backend uses the data-control protocol,
   which works without keyboard focus. Compositors that do not implement
   `ext-data-control-v1` or `zwlr_data_control_manager_v1` (e.g. GNOME
@@ -249,9 +254,9 @@ There are system level shortcuts to put screenshot image into your system clipbo
 - On Linux/Ubuntu, use `Ctrl+Shift+PrintScreen`
 - On Windows, use `Shift+Win+s`
 
-As described in the API documentation, the package supports read/write
-UTF8 encoded plain text or PNG encoded image data. Thus,
-the other types of data are not supported yet, i.e. undefined behavior.
+The built-in formats are UTF-8 encoded plain text (`FmtText`) and PNG encoded
+images (`FmtImage`). Arbitrary types can be exchanged as custom MIME formats via
+`Register` (raw passthrough). On mobile (iOS/Android) only text is supported.
 
 ## Who is using this package?
 

--- a/cmd/gclip-gui/README.md
+++ b/cmd/gclip-gui/README.md
@@ -8,8 +8,8 @@ The gclip GUI application writes a string to the system clipboard
 periodically then reads it back and renders it if possible.
 
 Because of the system limitation, on mobile devices, only string data is
-supported at the moment. Hence, one must use clipboard.FmtText. Other supplied
-formats result in a panic.
+supported at the moment. Hence, one must use clipboard.FmtText; other formats
+are unsupported there (Read returns nil and Write is a no-op).
 
 This example is intentded as cross platform application. To build it, one
 must use [gomobile](https://golang.org/x/mobile). You may follow the instructions


### PR DESCRIPTION
Final documentation pass before tagging **v0.8.0**.

- **README Features:** note Cgo-free desktop, non-PNG image input, `Watch`, and `Formats()`/`Format.MIME` enumeration.
- **Fix two stale caveats** the recent work contradicts:
  - "Image format … undefined behavior" → `Read(FmtImage)` always returns PNG; `Write` normalizes other encodings to PNG when the decoder is registered (#155).
  - "other types of data are not supported yet" → custom MIME formats via `Register` now exist (#17).
- **cmd/gclip-gui README:** other formats degrade gracefully on mobile (not "panic").
- **.gitignore** the built demo binaries (`gclip`/`gclip-gui`/`customformat`).

Docs-only. The package godoc, cmd tools, and specs were reviewed and are accurate (the cmd tools don't use the variadic `Watch`; specs are marked Implemented with Outcome sections)."